### PR TITLE
fix: prevent deployer OOM on super large clusters, graceful updater start

### DIFF
--- a/charts/onelensdeployer/templates/cronjob.yaml
+++ b/charts/onelensdeployer/templates/cronjob.yaml
@@ -64,11 +64,13 @@ spec:
                     secretKeyRef:
                       name: onelens-agent-secrets
                       key: REGISTRATION_ID
+                      optional: true
                 - name: CLUSTER_TOKEN
                   valueFrom:
                     secretKeyRef:
                       name: onelens-agent-secrets
                       key: CLUSTER_TOKEN
+                      optional: true
                 
           restartPolicy: {{ .Values.cronjob.restartPolicy }}
 {{- end }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,13 @@ if [ "$deployment_type" = "job" ]; then
 elif [ "$deployment_type" = "cronjob" ]; then
   SCRIPT_NAME="patching.sh"
 
+  # If secret doesn't exist (install not completed), exit gracefully
+  if [ -z "${REGISTRATION_ID:-}" ] || [ -z "${CLUSTER_TOKEN:-}" ]; then
+      echo "Credentials not available — install has not completed yet."
+      echo "The deployer job must finish successfully before the updater can run."
+      exit 0
+  fi
+
   # Check cluster version and patching status from API
   API_RESPONSE=$(curl -s --location --request POST "${API_ENDPOINT}/v1/kubernetes/cluster-version" \
     --header 'Content-Type: application/json' \

--- a/install.sh
+++ b/install.sh
@@ -174,8 +174,10 @@ detect_cloud_provider() {
         echo "AZURE"
     else
         # Fallback detection: Check node provider ID (backup method)
-        local node_provider
-        node_provider=$(kubectl get nodes -o jsonpath='{.items[0].spec.providerID}' 2>/dev/null || echo "")
+        # Fetch only one node to avoid loading all node objects into memory on large clusters
+        local _first_node node_provider
+        _first_node=$(kubectl get nodes --no-headers --chunk-size=1 2>/dev/null | head -1 | awk '{print $1}')
+        node_provider=$( [ -n "$_first_node" ] && kubectl get node "$_first_node" -o jsonpath='{.spec.providerID}' 2>/dev/null || echo "")
         if [[ "$node_provider" =~ ^aws:// ]]; then
             echo "AWS"
         elif [[ "$node_provider" =~ ^azure:// ]]; then
@@ -319,7 +321,7 @@ echo "Calculating cluster pod count..."
 echo "Checking cluster-wide read access..."
 _rbac_ready=false
 for _rw in 1 2 3 4 5 6; do
-    if kubectl get nodes --no-headers >/dev/null 2>&1; then
+    if kubectl auth can-i list nodes 2>/dev/null | grep -q "yes"; then
         _rbac_ready=true
         break
     fi
@@ -363,10 +365,10 @@ echo "Label density: $AVG_LABELS (default), multiplier: ${LABEL_MULTIPLIER}x"
 # --- GPU node detection ---
 GPU_NODE_COUNT=0
 TOTAL_GPU_COUNT=0
-gpu_capacities=$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.capacity.nvidia\.com/gpu}{"\n"}{end}' 2>/dev/null || true)
+gpu_capacities=$(kubectl get nodes --chunk-size=100 -o custom-columns='GPU:.status.capacity.nvidia\.com/gpu' --no-headers 2>/dev/null || true)
 if [ -n "$gpu_capacities" ]; then
-    GPU_NODE_COUNT=$(echo "$gpu_capacities" | awk '$1+0 > 0 {c++} END {print c+0}')
-    TOTAL_GPU_COUNT=$(echo "$gpu_capacities" | awk '{s+=$1} END {print s+0}')
+    GPU_NODE_COUNT=$(echo "$gpu_capacities" | awk '$1 != "<none>" && $1+0 > 0 {c++} END {print c+0}')
+    TOTAL_GPU_COUNT=$(echo "$gpu_capacities" | awk '$1 != "<none>" {s+=$1} END {print s+0}')
 fi
 if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     echo "GPU nodes: $GPU_NODE_COUNT nodes, $TOTAL_GPU_COUNT GPUs total"

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -290,7 +290,7 @@ NUM_PODS=$(kubectl get pods --all-namespaces --no-headers --chunk-size=500 \
     2>/dev/null | wc -l | tr -d '[:space:]')
 TOTAL_PODS=$(( NUM_PODS * 130 / 100 ))  # 30% buffer
 
-NUM_NODES=$(kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d '[:space:]')
+NUM_NODES=$(kubectl get nodes --no-headers --chunk-size=100 2>/dev/null | wc -l | tr -d '[:space:]')
 
 if [ "$TOTAL_PODS" -le 0 ]; then
     echo "WARNING: No active pods found. Using minimum tier."
@@ -311,10 +311,10 @@ echo "Label density: $AVG_LABELS (default), multiplier: ${LABEL_MULTIPLIER}x"
 # --- GPU node detection ---
 GPU_NODE_COUNT=0
 TOTAL_GPU_COUNT=0
-gpu_capacities=$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.capacity.nvidia\.com/gpu}{"\n"}{end}' 2>/dev/null || true)
+gpu_capacities=$(kubectl get nodes --chunk-size=100 -o custom-columns='GPU:.status.capacity.nvidia\.com/gpu' --no-headers 2>/dev/null || true)
 if [ -n "$gpu_capacities" ]; then
-    GPU_NODE_COUNT=$(echo "$gpu_capacities" | awk '$1+0 > 0 {c++} END {print c+0}')
-    TOTAL_GPU_COUNT=$(echo "$gpu_capacities" | awk '{s+=$1} END {print s+0}')
+    GPU_NODE_COUNT=$(echo "$gpu_capacities" | awk '$1 != "<none>" && $1+0 > 0 {c++} END {print c+0}')
+    TOTAL_GPU_COUNT=$(echo "$gpu_capacities" | awk '$1 != "<none>" {s+=$1} END {print s+0}')
 fi
 if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     echo "GPU nodes: $GPU_NODE_COUNT nodes, $TOTAL_GPU_COUNT GPUs total"
@@ -1826,14 +1826,11 @@ _remediate_scheduling_failure() {
     echo "  Pod memory requirement: $pod_memory"
     echo "  Checking node capacity..."
 
-    # Get allocatable memory across all nodes (single fast jq call, not per-node kubectl top)
-    # kubectl top is 30-60s per node (too slow); instead check if ANY node has allocatable memory
+    # Check if any node exists for rescheduling (all schedulable nodes have capacity).
     local nodes_with_capacity
-    nodes_with_capacity=$(kubectl get nodes -o json 2>/dev/null | jq -r '
-        .items[] |
-        select(.status.allocatable.memory != null) |
-        .metadata.name
-    ' 2>/dev/null | head -1)
+    # Fetch one node name — all schedulable nodes have allocatable.memory.
+    # Uses --chunk-size=1 to avoid loading all node objects on large clusters.
+    nodes_with_capacity=$(kubectl get nodes --no-headers --chunk-size=1 2>/dev/null | head -1 | awk '{print $1}')
 
     if [ -n "$nodes_with_capacity" ]; then
         echo "  ✅ Found node with capacity: $nodes_with_capacity"

--- a/tests/test-entrypoint.sh
+++ b/tests/test-entrypoint.sh
@@ -158,6 +158,35 @@ pv_export=$(grep -c 'export PATCHING_VERSION' "$ENTRYPOINT" || true)
 assert_eq "$pv_export" "2" "PATCHING_VERSION exported in both healthcheck and oneshot paths"
 
 ###############################################################################
+# Test 21: CronJob path checks for empty credentials before API call
+###############################################################################
+# The credential check must appear BEFORE the first curl call in the cronjob branch
+cronjob_block=$(sed -n '/deployment_type.*=.*cronjob/,/deployment_type/p' "$ENTRYPOINT" | head -30)
+cred_check=$(echo "$cronjob_block" | grep -c 'REGISTRATION_ID:-' || true)
+assert_gt "$cred_check" "0" "cronjob path checks for empty REGISTRATION_ID"
+
+cred_check_token=$(echo "$cronjob_block" | grep -c 'CLUSTER_TOKEN:-' || true)
+assert_gt "$cred_check_token" "0" "cronjob path checks for empty CLUSTER_TOKEN"
+
+###############################################################################
+# Test 22: Credential check exits 0 (not error) when secret missing
+###############################################################################
+cred_exit=$(sed -n '/Credentials not available/,+2p' "$ENTRYPOINT" | grep -c 'exit 0' || true)
+assert_gt "$cred_exit" "0" "missing credentials exits 0 (graceful, not error)"
+
+###############################################################################
+# Test 23: Credential check comes before API POST call in cronjob block
+###############################################################################
+# Line number of credential check must be less than line number of the POST curl (cronjob API call)
+cred_line=$(grep -n 'REGISTRATION_ID:-' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+api_curl_line=$(grep -n 'request POST.*cluster-version' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+if [ -n "$cred_line" ] && [ -n "$api_curl_line" ]; then
+    assert_gt "$api_curl_line" "$cred_line" "credential check runs before API POST call"
+else
+    assert_eq "1" "0" "could not find credential check or API POST line numbers"
+fi
+
+###############################################################################
 # Summary
 ###############################################################################
 test_summary

--- a/tests/test-parity.sh
+++ b/tests/test-parity.sh
@@ -263,5 +263,46 @@ patching_repo_add=$(grep -c 'helm repo add onelens' "$ROOT/src/patching.sh" || t
 assert_gt "$install_repo_add" "0" "install.sh still has helm repo add for standard path"
 assert_gt "$patching_repo_add" "0" "patching.sh still has helm repo add for standard path"
 
+# ---------------------------------------------------------------------------
+# Test 30: Both scripts use --chunk-size for GPU node detection
+# ---------------------------------------------------------------------------
+install_gpu_chunk=$(grep 'gpu_capacities=' "$ROOT/install.sh" | grep -c 'chunk-size' || true)
+patching_gpu_chunk=$(grep 'gpu_capacities=' "$ROOT/src/patching.sh" | grep -c 'chunk-size' || true)
+assert_gt "$install_gpu_chunk" "0" "install.sh GPU detection uses --chunk-size"
+assert_gt "$patching_gpu_chunk" "0" "patching.sh GPU detection uses --chunk-size"
+
+# ---------------------------------------------------------------------------
+# Test 31: Both scripts use custom-columns for GPU detection (not jsonpath)
+# ---------------------------------------------------------------------------
+install_gpu_cols=$(grep 'gpu_capacities=' "$ROOT/install.sh" | grep -c 'custom-columns' || true)
+patching_gpu_cols=$(grep 'gpu_capacities=' "$ROOT/src/patching.sh" | grep -c 'custom-columns' || true)
+assert_gt "$install_gpu_cols" "0" "install.sh GPU detection uses custom-columns"
+assert_gt "$patching_gpu_cols" "0" "patching.sh GPU detection uses custom-columns"
+
+# ---------------------------------------------------------------------------
+# Test 32: Both scripts filter <none> in GPU awk parsing
+# ---------------------------------------------------------------------------
+install_gpu_none=$(grep -c '"<none>"' "$ROOT/install.sh" || true)
+patching_gpu_none=$(grep -c '"<none>"' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_gpu_none" "0" "install.sh GPU awk filters <none>"
+assert_gt "$patching_gpu_none" "0" "patching.sh GPU awk filters <none>"
+
+# ---------------------------------------------------------------------------
+# Test 33: Neither script uses kubectl get nodes -o jsonpath (loads all nodes)
+# ---------------------------------------------------------------------------
+# All node queries must use --chunk-size or single-node patterns to bound memory.
+install_nodes_jsonpath=$(grep 'kubectl get nodes' "$ROOT/install.sh" | grep -v '#' | grep -c '\-o jsonpath' || true)
+patching_nodes_jsonpath=$(grep 'kubectl get nodes' "$ROOT/src/patching.sh" | grep -v '#' | grep -c '\-o jsonpath' || true)
+assert_eq "$install_nodes_jsonpath" "0" "install.sh has no kubectl get nodes -o jsonpath (OOM risk)"
+assert_eq "$patching_nodes_jsonpath" "0" "patching.sh has no kubectl get nodes -o jsonpath (OOM risk)"
+
+# ---------------------------------------------------------------------------
+# Test 34: Neither script uses kubectl get nodes -o json (loads all nodes)
+# ---------------------------------------------------------------------------
+install_nodes_json=$(grep 'kubectl get nodes' "$ROOT/install.sh" | grep -v '#' | grep -c '\-o json ' || true)
+patching_nodes_json=$(grep 'kubectl get nodes' "$ROOT/src/patching.sh" | grep -v '#' | grep -c '\-o json ' || true)
+assert_eq "$install_nodes_json" "0" "install.sh has no kubectl get nodes -o json (OOM risk)"
+assert_eq "$patching_nodes_json" "0" "patching.sh has no kubectl get nodes -o json (OOM risk)"
+
 test_summary
 exit $?


### PR DESCRIPTION
## Summary
- Replace 6 unbounded `kubectl get nodes` calls with memory-bounded alternatives (`--chunk-size`, single-node queries, `auth can-i`) to prevent OOM on clusters with 2000+ nodes
- Make cronjob secret refs optional + add entrypoint credential check so updater starts gracefully when install hasn't completed
- 14 new tests (744 total, 0 failures)

## Test plan
- [x] All 744 tests passing (17 suites)
- [x] All 6 changed kubectl commands verified on live EKS cluster (old vs new output identical)
- [x] Full install.sh flow tested end-to-end on test cluster
- [x] Full patching.sh flow tested end-to-end on test cluster
- [x] Entrypoint credential check tested with empty and valid credentials
- [x] `helm template` verified optional: true renders correctly
- [x] Fleet impact reviewed — safe for all 122 connected clusters