### PR TITLE
fix: deployer OOM on pod counting for clusters with 2400+ pods

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,12 +338,21 @@ if [ "$_rbac_ready" != "true" ]; then
     exit 1
 fi
 
-# Count active pods (Running, Pending, ContainerCreating) using server-side field-selector.
-# Single kubectl call with --chunk-size=500 keeps memory bounded (~500 pods of JSON at a time)
-# regardless of cluster size. Excludes completed/failed job pods.
-NUM_PODS=$(kubectl get pods --all-namespaces --no-headers --chunk-size=500 \
-    --field-selector='status.phase!=Succeeded,status.phase!=Failed' \
-    2>/dev/null | wc -l | tr -d '[:space:]')
+# Count active pods using raw API pagination — truly memory-bounded.
+# kubectl get --all-namespaces buffers ALL objects in Go heap regardless of --chunk-size.
+# Raw API with limit=100 keeps memory at ~43MB flat (kubectl acts as HTTP passthrough,
+# no Go object deserialization). Each page is counted via jq and discarded.
+NUM_PODS=0
+_continue=""
+while true; do
+    _url="/api/v1/pods?limit=100&fieldSelector=status.phase%21%3DSucceeded%2Cstatus.phase%21%3DFailed"
+    [ -n "$_continue" ] && _url="${_url}&continue=${_continue}"
+    _resp=$(kubectl get --raw "$_url" 2>/dev/null) || break
+    _page_count=$(echo "$_resp" | jq '.items | length')
+    NUM_PODS=$(( NUM_PODS + _page_count ))
+    _continue=$(echo "$_resp" | jq -r '.metadata.continue // empty')
+    [ -z "$_continue" ] && break
+done
 TOTAL_PODS=$(( NUM_PODS * 130 / 100 ))  # 30% buffer
 
 if [ "$TOTAL_PODS" -le 0 ]; then

--- a/install.sh
+++ b/install.sh
@@ -348,9 +348,9 @@ while true; do
     _url="/api/v1/pods?limit=100&fieldSelector=status.phase%21%3DSucceeded%2Cstatus.phase%21%3DFailed"
     [ -n "$_continue" ] && _url="${_url}&continue=${_continue}"
     _resp=$(kubectl get --raw "$_url" 2>/dev/null) || break
-    _page_count=$(echo "$_resp" | jq '.items | length')
+    _page_count=$(echo "$_resp" | jq '.items | length') || break
     NUM_PODS=$(( NUM_PODS + _page_count ))
-    _continue=$(echo "$_resp" | jq -r '.metadata.continue // empty')
+    _continue=$(echo "$_resp" | jq -r '.metadata.continue // empty') || break
     [ -z "$_continue" ] && break
 done
 TOTAL_PODS=$(( NUM_PODS * 130 / 100 ))  # 30% buffer

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -282,12 +282,21 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/resource-sizing.sh"
 echo "Calculating cluster pod count..."
 _report_milestone  # M4: pod-counting-start
 
-# Count active pods (Running, Pending, ContainerCreating) using server-side field-selector.
-# Single kubectl call with --chunk-size=500 keeps memory bounded (~500 pods of JSON at a time)
-# regardless of cluster size. Excludes completed/failed job pods.
-NUM_PODS=$(kubectl get pods --all-namespaces --no-headers --chunk-size=500 \
-    --field-selector='status.phase!=Succeeded,status.phase!=Failed' \
-    2>/dev/null | wc -l | tr -d '[:space:]')
+# Count active pods using raw API pagination — truly memory-bounded.
+# kubectl get --all-namespaces buffers ALL objects in Go heap regardless of --chunk-size.
+# Raw API with limit=100 keeps memory at ~43MB flat (kubectl acts as HTTP passthrough,
+# no Go object deserialization). Each page is counted via jq and discarded.
+NUM_PODS=0
+_continue=""
+while true; do
+    _url="/api/v1/pods?limit=100&fieldSelector=status.phase%21%3DSucceeded%2Cstatus.phase%21%3DFailed"
+    [ -n "$_continue" ] && _url="${_url}&continue=${_continue}"
+    _resp=$(kubectl get --raw "$_url" 2>/dev/null) || break
+    _page_count=$(echo "$_resp" | jq '.items | length')
+    NUM_PODS=$(( NUM_PODS + _page_count ))
+    _continue=$(echo "$_resp" | jq -r '.metadata.continue // empty')
+    [ -z "$_continue" ] && break
+done
 TOTAL_PODS=$(( NUM_PODS * 130 / 100 ))  # 30% buffer
 
 NUM_NODES=$(kubectl get nodes --no-headers --chunk-size=100 2>/dev/null | wc -l | tr -d '[:space:]')

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -292,9 +292,9 @@ while true; do
     _url="/api/v1/pods?limit=100&fieldSelector=status.phase%21%3DSucceeded%2Cstatus.phase%21%3DFailed"
     [ -n "$_continue" ] && _url="${_url}&continue=${_continue}"
     _resp=$(kubectl get --raw "$_url" 2>/dev/null) || break
-    _page_count=$(echo "$_resp" | jq '.items | length')
+    _page_count=$(echo "$_resp" | jq '.items | length') || break
     NUM_PODS=$(( NUM_PODS + _page_count ))
-    _continue=$(echo "$_resp" | jq -r '.metadata.continue // empty')
+    _continue=$(echo "$_resp" | jq -r '.metadata.continue // empty') || break
     [ -z "$_continue" ] && break
 done
 TOTAL_PODS=$(( NUM_PODS * 130 / 100 ))  # 30% buffer

--- a/tests/test-build.sh
+++ b/tests/test-build.sh
@@ -137,12 +137,12 @@ terminated_case=$(grep -c 'Terminated)' "$SRC_FILE" || true)
 assert_ge "$terminated_case" "1" "src/patching.sh has explicit Terminated case in pod remediation"
 
 ###############################################################################
-# Test 14: Pod counting uses field-selector (not per-namespace loop)
-# Per-namespace counting spawns 77+ kubectl processes on a 25-namespace cluster,
-# causing OOM on the 256Mi CronJob container. Field-selector is server-side.
+# Test 14: Pod counting uses raw API pagination (not per-namespace loop)
+# kubectl get --all-namespaces buffers ALL objects in Go heap regardless of
+# --chunk-size. Raw API with limit=100 keeps memory bounded at ~43MB.
 ###############################################################################
-chunk_size=$(grep -c 'chunk-size=500' "$SRC_FILE" || true)
-assert_ge "$chunk_size" "1" "src/patching.sh uses --chunk-size=500 for memory-bounded pod counting"
+raw_api=$(grep -c 'get --raw' "$SRC_FILE" || true)
+assert_ge "$raw_api" "1" "src/patching.sh uses kubectl get --raw for memory-bounded pod counting"
 
 per_ns_loop=$(grep -c 'kubectl get deployments -n' "$SRC_FILE" || true)
 assert_eq "$per_ns_loop" "0" "src/patching.sh has no per-namespace deployment counting"

--- a/tests/test-parity.sh
+++ b/tests/test-parity.sh
@@ -23,10 +23,10 @@ assert_gt "$install_tier" "0" "install.sh calls select_resource_tier"
 assert_gt "$patching_tier" "0" "patching.sh calls select_resource_tier"
 
 # ---------------------------------------------------------------------------
-# Test 3: Both scripts use chunked field-selector pod counting
+# Test 3: Both scripts use raw API pagination for pod counting
 # ---------------------------------------------------------------------------
-# Single kubectl call with --chunk-size=500 and exclusion filter.
-for pattern in 'chunk-size=500' 'status.phase!=Succeeded'; do
+# kubectl get --raw with limit=100 and fieldSelector URL encoding.
+for pattern in 'get --raw' 'fieldSelector=status.phase'; do
     install_has=$(grep -c "$pattern" "$ROOT/install.sh" || true)
     patching_has=$(grep -c "$pattern" "$ROOT/src/patching.sh" || true)
     assert_gt "$install_has" "0" "install.sh uses $pattern"


### PR DESCRIPTION
## Summary
- Replace `kubectl get pods --all-namespaces --chunk-size=500` with `kubectl get --raw` paginated API calls (limit=100) for pod counting
- `--chunk-size` does NOT bound kubectl client memory — kubectl buffers ALL objects in Go heap regardless (proven: 48.5s to first output, ~83KB/pod)
- At 256Mi deployer limit, OOM at ~2400 pods. New approach keeps memory flat at ~43MB
- All jq lines protected with `|| break` for `set -e` safety in install.sh

## Test plan
- [x] 744 tests passing, 0 failures
- [x] Old vs new count match on test EKS cluster (exact: 45 = 45)
- [x] Multi-page pagination verified (9 pages with limit=5)
- [x] Error handling: bad URL, bad fieldSelector, garbled JSON all fall through gracefully
- [x] `set -e` safety verified — jq failure exits loop, doesn't kill script
- [ ] E2E: deploy to customer cluster with 2400+ pods (post-merge)