### PR TITLE
fix: CronJob image sidecar-safety + raise agent memory cap (v2.1.65 regression)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -392,8 +392,18 @@ fi
 # --- Air-gapped self-detection ---
 # If the deployer pod's image is NOT from public.ecr.aws, this is an air-gapped cluster.
 # Extract the private registry URL from the image path for chart pulls and image overrides.
+#
+# Read image by container name (onelensdeployerjob) — NOT containers[0]. Sidecar injectors
+# (Dynatrace, Istio, etc.) may insert containers at index 0 of the install Job's pod,
+# which would make us read the sidecar's image and misdetect air-gapped mode.
 REGISTRY_URL=""
-MY_IMAGE=$(kubectl get pod "$HOSTNAME" -n onelens-agent -o jsonpath='{.spec.containers[0].image}' 2>/dev/null || true)
+MY_IMAGE=$(kubectl get pod "$HOSTNAME" -n onelens-agent -o jsonpath='{.spec.containers[?(@.name=="onelensdeployerjob")].image}' 2>/dev/null || true)
+# Fallback for older charts or customizations where the container name differs:
+# pick any container image whose path contains "onelens-deployer".
+if [ -z "$MY_IMAGE" ] || ! echo "$MY_IMAGE" | grep -q 'onelens-deployer'; then
+    MY_IMAGE=$(kubectl get pod "$HOSTNAME" -n onelens-agent -o jsonpath='{.spec.containers[*].image}' 2>/dev/null \
+        | tr ' ' '\n' | grep 'onelens-deployer' | head -1 || true)
+fi
 if [ -n "$MY_IMAGE" ] && echo "$MY_IMAGE" | grep -qv "public.ecr.aws"; then
     REGISTRY_URL=$(echo "$MY_IMAGE" | sed 's|/onelens-deployer.*||')
     echo "Air-gapped mode detected. Registry: $REGISTRY_URL"

--- a/lib/resource-sizing.sh
+++ b/lib/resource-sizing.sh
@@ -94,7 +94,7 @@ _USAGE_FLOOR_CPU=50          # tiny tier minimum CPU (millicores)
 _USAGE_CAP_PROM_MEM=8192    # max Prometheus memory for mega clusters (Mi)
 _USAGE_CAP_KSM_MEM=4800     # max KSM memory for mega clusters (Mi)
 _USAGE_CAP_OPENCOST_MEM=4800 # max OpenCost memory for mega clusters (Mi)
-_USAGE_CAP_AGENT_MEM=4096   # max agent memory for mega clusters (4000+ pods)
+_USAGE_CAP_AGENT_MEM=8192   # max agent memory (raised 4096→8192 in v2.1.66; agent mem scales with metric cardinality/cost data volume, not just pod count — 5 customer clusters hit the 4GB cap)
 _USAGE_CAP_CPU=1200          # 2x very-large maximum CPU (millicores)
 
 # apply_cpu_multiplier "$cpu_str" "$multiplier"

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -1811,9 +1811,11 @@ _remediate_oomkilled_pod() {
     echo ""
     echo "🔧 Attempting remediation: OOMKilled pod $pod_name"
 
-    # Get current memory limit
+    # Get current memory limit — read by container name to avoid picking up a
+    # sidecar at containers[0]. A wrong read would feed into kubectl set resources
+    # below and silently mis-size the deployment.
     current_memory=$(kubectl get pod "$pod_name" -n onelens-agent \
-        -o jsonpath='{.spec.containers[0].resources.limits.memory}' 2>/dev/null)
+        -o jsonpath="{.spec.containers[?(@.name==\"$component\")].resources.limits.memory}" 2>/dev/null)
 
     if [ -z "$current_memory" ]; then
         echo "⚠️  Cannot determine current memory limit for $pod_name"
@@ -2337,9 +2339,20 @@ if [ -n "$AGENT_CJ_EXISTS" ]; then
     AGENT_SUSPENDED=$(kubectl get cronjob "$AGENT_CJ_NAME" -n onelens-agent -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "unknown")
     AGENT_LAST_SCHEDULE=$(kubectl get cronjob "$AGENT_CJ_NAME" -n onelens-agent -o jsonpath='{.status.lastScheduleTime}' 2>/dev/null || true)
     AGENT_BACKOFF=$(kubectl get cronjob "$AGENT_CJ_NAME" -n onelens-agent -o jsonpath='{.spec.jobTemplate.spec.backoffLimit}' 2>/dev/null || true)
-    # Read actual container name from CronJob spec (don't assume it matches CronJob name)
+    # Read actual container name from CronJob spec — NEVER via containers[0].name.
+    # Sidecar injectors (Dynatrace, Istio) may insert at index 0; subsequent patches
+    # use this name as the strategic-merge merge-key, so picking the sidecar would
+    # silently target the wrong container. Try three resolution strategies in order.
     AGENT_CONTAINER_NAME=$(kubectl get cronjob "$AGENT_CJ_NAME" -n onelens-agent \
-        -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].name}' 2>/dev/null || echo "$AGENT_CJ_NAME")
+        -o jsonpath="{.spec.jobTemplate.spec.template.spec.containers[?(@.name==\"$AGENT_CJ_NAME\")].name}" 2>/dev/null || true)
+    if [ -z "$AGENT_CONTAINER_NAME" ]; then
+        AGENT_CONTAINER_NAME=$(kubectl get cronjob "$AGENT_CJ_NAME" -n onelens-agent \
+            -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[*].name}' 2>/dev/null \
+            | tr ' ' '\n' | grep 'onelens-agent' | head -1 || true)
+    fi
+    if [ -z "$AGENT_CONTAINER_NAME" ]; then
+        AGENT_CONTAINER_NAME="$AGENT_CJ_NAME"
+    fi
 
     echo "CronJob: schedule=$(kubectl get cronjob "$AGENT_CJ_NAME" -n onelens-agent -o jsonpath='{.spec.schedule}' 2>/dev/null) suspend=$AGENT_SUSPENDED lastSchedule=$AGENT_LAST_SCHEDULE backoffLimit=${AGENT_BACKOFF:-default} container=$AGENT_CONTAINER_NAME"
 
@@ -2414,8 +2427,9 @@ if [ -n "$AGENT_CJ_EXISTS" ]; then
                     AGENT_EXIT_CODE=$(kubectl get pod "$AGENT_FAIL_POD" -n onelens-agent \
                         -o jsonpath='{.status.containerStatuses[0].lastState.terminated.exitCode}' 2>/dev/null || true)
                 fi
+                # Read by container name — sidecar injection risk if we used containers[0].
                 AGENT_MEM_LIMIT=$(kubectl get pod "$AGENT_FAIL_POD" -n onelens-agent \
-                    -o jsonpath='{.spec.containers[0].resources.limits.memory}' 2>/dev/null || true)
+                    -o jsonpath="{.spec.containers[?(@.name==\"$AGENT_CONTAINER_NAME\")].resources.limits.memory}" 2>/dev/null || true)
 
                 echo "Diagnosis: pod=$AGENT_FAIL_POD reason=$AGENT_TERM_REASON exitCode=$AGENT_EXIT_CODE memLimit=$AGENT_MEM_LIMIT"
 
@@ -2441,8 +2455,11 @@ if [ -n "$AGENT_CJ_EXISTS" ]; then
 
                 # Fix: if cgroup CPU error, round CPU to next 100m via kubectl patch
                 if [ "$AGENT_EXIT_CODE" = "128" ] && echo "$AGENT_FAIL_EVENTS" | grep -qiE 'cgroup.*cpu|cpu.*cgroup|cfs_quota' 2>/dev/null; then
+                    # Read by container name — sidecar injection risk: if containers[0]
+                    # is a sidecar with lower CPU, AGENT_NEW_CPU would be calculated from
+                    # the sidecar's value and patch would downsize the agent's CPU.
                     AGENT_CPU_LIMIT=$(kubectl get pod "$AGENT_FAIL_POD" -n onelens-agent \
-                        -o jsonpath='{.spec.containers[0].resources.limits.cpu}' 2>/dev/null || true)
+                        -o jsonpath="{.spec.containers[?(@.name==\"$AGENT_CONTAINER_NAME\")].resources.limits.cpu}" 2>/dev/null || true)
                     AGENT_CPU_MC=$(_cpu_to_millicores "${AGENT_CPU_LIMIT:-400m}")
                     if [ "$AGENT_CPU_MC" -ge "$_USAGE_CAP_CPU" ] 2>/dev/null; then
                         echo "Agent cgroup CPU error but already at cap (${AGENT_CPU_LIMIT}). Manual investigation needed."

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -165,9 +165,12 @@ fi
 
 # Set CronJob resources: 200m CPU. Memory depends on OOM state.
 # Note: _cpu_to_millicores is not available yet (library embedded below), so parse manually.
+# Read by container name (not containers[0]) — sidecar injectors (Dynatrace, Istio)
+# may insert containers at index 0, which would give us the sidecar's resources
+# instead of onelensupdater's, causing wrong patch decisions.
 TARGET_CPU_MILLICORES=200
-CURRENT_CPU=$(kubectl get cronjob onelensupdater -n onelens-agent -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
-CURRENT_MEM=$(kubectl get cronjob onelensupdater -n onelens-agent -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory}' 2>/dev/null || true)
+CURRENT_CPU=$(kubectl get cronjob onelensupdater -n onelens-agent -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[?(@.name=="onelensupdater")].resources.requests.cpu}' 2>/dev/null || true)
+CURRENT_MEM=$(kubectl get cronjob onelensupdater -n onelens-agent -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[?(@.name=="onelensupdater")].resources.requests.memory}' 2>/dev/null || true)
 
 # Parse current memory to Mi for comparison
 CURRENT_MEM_MI=""
@@ -216,10 +219,24 @@ if [ -n "$CURRENT_MEM_MI" ] && [ "$CURRENT_MEM_MI" -lt "$TARGET_MEMORY_MI" ] 2>/
 fi
 
 if [ "$NEED_CPU_PATCH" = "true" ] || [ "$NEED_MEM_PATCH" = "true" ]; then
+    # Read image by container name — NOT by array index. Sidecar injectors
+    # (Dynatrace, Istio, etc.) may insert containers at index zero, which would
+    # return the sidecar's image instead of onelensupdater's. The strategic-merge
+    # patch uses name=onelensupdater as merge key so it correctly finds the
+    # onelensupdater container, but writing the wrong image field would corrupt
+    # the CronJob (the v2.1.65 regression — fixed here in v2.1.66).
     UPDATER_IMAGE=$(kubectl get cronjob onelensupdater -n onelens-agent \
-        -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+        -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[?(@.name=="onelensupdater")].image}' 2>/dev/null || true)
     if [ -z "$UPDATER_IMAGE" ]; then
-        echo "WARNING: Skipping CronJob resource patch — container image not found"
+        echo "WARNING: Skipping CronJob resource patch — onelensupdater container image not found"
+    elif ! echo "$UPDATER_IMAGE" | grep -q 'onelens-deployer'; then
+        # Sanity guard: image must look like a deployer image. If not, the CronJob
+        # was likely corrupted by the v2.1.65 bug. Refuse to patch — otherwise we
+        # would re-apply the corrupted image and lock it in. Manual recovery required.
+        echo "ERROR: Refusing to patch — onelensupdater image '$UPDATER_IMAGE' does not look like an onelens-deployer image."
+        echo "       Previous state: CURRENT_CPU=${CURRENT_CPU:-unset}, CURRENT_MEM=${CURRENT_MEM:-unset}"
+        echo "       CronJob may have been corrupted by a prior bad patch (v2.1.65 sidecar-injection bug)."
+        echo "       Manual recovery required — contact support to reset the CronJob image."
     else
         echo "Updating CronJob resources (cpu=${CURRENT_CPU:-?}→${TARGET_CPU_MILLICORES}m, mem=${CURRENT_MEM:-?}→${TARGET_MEMORY_MI}Mi)..."
         kubectl patch cronjob onelensupdater -n onelens-agent --type='merge' --field-manager='Helm' -p="{
@@ -2440,10 +2457,20 @@ if [ -n "$AGENT_CJ_EXISTS" ]; then
                             AGENT_NEW_CPU="$_USAGE_CAP_CPU"
                         fi
                         echo "Agent cgroup CPU error — patching CronJob CPU ${AGENT_CPU_LIMIT} -> ${AGENT_NEW_CPU}m"
+                        # Read image by container name (not containers[0]) to avoid reading a
+                        # sidecar image injected by Dynatrace/Istio. Strategic-merge patch uses
+                        # name as merge key so it targets the right container, but a wrong image
+                        # value would corrupt the CronJob (v2.1.65 sidecar bug — fixed v2.1.66).
                         AGENT_IMAGE=$(kubectl get cronjob "$AGENT_CJ_NAME" -n onelens-agent \
-                            -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+                            -o jsonpath="{.spec.jobTemplate.spec.template.spec.containers[?(@.name==\"$AGENT_CONTAINER_NAME\")].image}" 2>/dev/null || true)
                         if [ -z "$AGENT_IMAGE" ]; then
-                            echo "WARNING: Skipping agent CronJob CPU patch — container image not found"
+                            echo "WARNING: Skipping agent CronJob CPU patch — agent container image not found"
+                        elif ! echo "$AGENT_IMAGE" | grep -q 'onelens-agent'; then
+                            # Sanity guard: refuse if image doesn't look like an agent image
+                            # (prevents re-applying a corrupted image from a prior bad patch).
+                            echo "ERROR: Refusing to patch — agent image '$AGENT_IMAGE' does not look like an onelens-agent image."
+                            echo "       Previous state: AGENT_CPU_LIMIT=${AGENT_CPU_LIMIT:-unset}"
+                            echo "       May indicate CronJob corruption. Manual recovery required — contact support."
                         else
                             _agent_cpu_patch_err=$(kubectl patch cronjob "$AGENT_CJ_NAME" -n onelens-agent --type='merge' --field-manager='Helm' -p="{
                               \"spec\":{\"jobTemplate\":{\"spec\":{\"template\":{\"spec\":{\"containers\":[{

--- a/tests/test-airgapped.sh
+++ b/tests/test-airgapped.sh
@@ -198,5 +198,22 @@ assert_eq "$patching_ips" "0" "patching.sh does not set imagePullSecrets"
 migrate_configmap=$(grep -c 'configmap onelens-agent-chart' "$MIGRATE" || true)
 assert_gt "$migrate_configmap" "0" "migration script creates ConfigMap onelens-agent-chart"
 
+# ---------------------------------------------------------------------------
+# Test 28: install.sh MY_IMAGE read uses name-selector, not containers[0]
+# v2.1.65 regression carried the same bug to install.sh — sidecar injectors
+# (Dynatrace, Istio) may insert at containers[0], causing misdetection of
+# air-gapped mode from the sidecar's image path. v2.1.66 reads by name.
+# ---------------------------------------------------------------------------
+install_image_name_selector=$(grep -c 'containers\[?(@.name=="onelensdeployerjob")\].image' "$ROOT/install.sh" || true)
+assert_gt "$install_image_name_selector" "0" "install.sh reads deployer pod image via name-selector (not containers[0])"
+
+install_image_bad_index=$(grep -c 'MY_IMAGE=.*kubectl get pod.*containers\[0\]\.image' "$ROOT/install.sh" || true)
+assert_eq "$install_image_bad_index" "0" "install.sh MY_IMAGE read does not use containers[0] (sidecar safety)"
+
+# Fallback: install.sh must filter containers[*].image for onelens-deployer substring
+# when the primary name-selector returns empty (covers forks/customizations).
+install_image_fallback=$(grep -c "grep 'onelens-deployer'" "$ROOT/install.sh" || true)
+assert_gt "$install_image_fallback" "0" "install.sh has substring fallback for MY_IMAGE when name-selector fails"
+
 test_summary
 exit $?

--- a/tests/test-build.sh
+++ b/tests/test-build.sh
@@ -243,5 +243,37 @@ assert_ge "$updater_image_sanity" "1" "src/patching.sh sanity-guards updater ima
 agent_image_sanity=$(grep -c "AGENT_IMAGE\".*grep.*'onelens-agent'" "$SRC_FILE" || true)
 assert_ge "$agent_image_sanity" "1" "src/patching.sh sanity-guards agent image (refuses patch if not onelens-agent)"
 
+###############################################################################
+# Test 22: Agent pod resource reads (CPU/memory limits) use name-selector
+# Caught by post-v2.1.66 review: AGENT_CPU_LIMIT read from containers[0] could
+# cause agent CPU DOWNSIZE if a sidecar with lower CPU limit is injected at [0].
+# AGENT_CONTAINER_NAME read from containers[0] could make subsequent patches
+# target the sidecar's name as merge-key.
+###############################################################################
+agent_cpu_name_selector=$(grep -c 'containers\[?(@.name==\\"\$AGENT_CONTAINER_NAME\\")\].resources.limits.cpu' "$SRC_FILE" || true)
+assert_ge "$agent_cpu_name_selector" "1" "src/patching.sh reads agent CPU limit via name-selector (downsize prevention)"
+
+agent_mem_name_selector=$(grep -c 'containers\[?(@.name==\\"\$AGENT_CONTAINER_NAME\\")\].resources.limits.memory' "$SRC_FILE" || true)
+assert_ge "$agent_mem_name_selector" "1" "src/patching.sh reads agent memory limit via name-selector"
+
+agent_name_resolution=$(grep -c 'containers\[?(@.name==\\"\$AGENT_CJ_NAME\\")\].name' "$SRC_FILE" || true)
+assert_ge "$agent_name_resolution" "1" "src/patching.sh resolves AGENT_CONTAINER_NAME via name-selector (not containers[0])"
+
+# Negative: no agent pod containers[0] reads for CPU/memory limits
+agent_pod_bad_index=$(grep -cE 'containers\[0\]\.resources\.limits\.(cpu|memory)' "$SRC_FILE" || true)
+# Allow up to 1 occurrence because deployment OOM handler and scheduling failure handler
+# read deployment pod resources; we fix _remediate_oomkilled_pod but defer _remediate_scheduling_failure.
+# This assertion ensures the agent-path reads are gone.
+agent_path_bad_reads=$(grep -v '^[[:space:]]*#' "$SRC_FILE" | grep -B2 'containers\[0\]\.resources\.limits\.cpu' | grep -c 'AGENT' || true)
+assert_eq "$agent_path_bad_reads" "0" "src/patching.sh agent CPU limit read does not use containers[0]"
+
+###############################################################################
+# Test 23: Deployment OOM remediation reads memory by container name
+# _remediate_oomkilled_pod feeds into kubectl set resources — wrong read would
+# cause silent mis-sizing of Prometheus/KSM/OpenCost deployments.
+###############################################################################
+oom_remediate_name_selector=$(grep -c 'containers\[?(@.name==\\"\$component\\")\].resources.limits.memory' "$SRC_FILE" || true)
+assert_ge "$oom_remediate_name_selector" "1" "src/patching.sh _remediate_oomkilled_pod reads memory via name-selector"
+
 test_summary
 exit $?

--- a/tests/test-build.sh
+++ b/tests/test-build.sh
@@ -199,5 +199,49 @@ assert_ge "$agent_oom_prehlem" "1" "src/patching.sh bumps agent memory via helm 
 agent_mem_kubectl=$(grep -c 'kubectl patch.*AGENT_CJ_NAME.*memory' "$SRC_FILE" || true)
 assert_eq "$agent_mem_kubectl" "0" "src/patching.sh does NOT kubectl patch agent CronJob memory (uses helm instead)"
 
+###############################################################################
+# Test 19: CronJob image reads use name-selector, not containers[0]
+# v2.1.65 regression: sidecar injectors (Dynatrace, Istio) can insert containers
+# at index 0, causing containers[0].image to return the sidecar's image. The
+# strategic-merge patch would then rewrite the targeted container's image with
+# the sidecar's image, silently breaking the CronJob. v2.1.66 fixes this by
+# reading the image via jsonpath name-selector.
+###############################################################################
+# Positive: name-selector is used for image reads
+updater_image_name_selector=$(grep -c 'containers\[?(@.name=="onelensupdater")\].image' "$SRC_FILE" || true)
+assert_ge "$updater_image_name_selector" "1" "src/patching.sh reads updater image via name-selector (not containers[0])"
+
+agent_image_name_selector=$(grep -c 'containers\[?(@.name==\\"\$AGENT_CONTAINER_NAME\\")\].image' "$SRC_FILE" || true)
+assert_ge "$agent_image_name_selector" "1" "src/patching.sh reads agent image via name-selector (not containers[0])"
+
+# Negative: image-reads that feed into kubectl-patch must not use containers[0]
+updater_image_bad_index=$(grep -c 'UPDATER_IMAGE=.*kubectl get cronjob.*containers\[0\]\.image' "$SRC_FILE" || true)
+assert_eq "$updater_image_bad_index" "0" "src/patching.sh updater image-read does not use containers[0] (sidecar safety)"
+
+agent_image_bad_index=$(grep -c 'AGENT_IMAGE=.*kubectl get cronjob.*containers\[0\]\.image' "$SRC_FILE" || true)
+assert_eq "$agent_image_bad_index" "0" "src/patching.sh agent image-read does not use containers[0] (sidecar safety)"
+
+###############################################################################
+# Test 20: CronJob resource reads (CPU/mem) also use name-selector
+# Reads feed into patch-or-skip decisions — if a sidecar's resources are read
+# instead, the script may wrongly decide "already at target" and skip bumping.
+###############################################################################
+updater_cpu_name_selector=$(grep -c 'containers\[?(@.name=="onelensupdater")\].resources.requests.cpu' "$SRC_FILE" || true)
+assert_ge "$updater_cpu_name_selector" "1" "src/patching.sh reads updater CPU via name-selector"
+
+updater_mem_name_selector=$(grep -c 'containers\[?(@.name=="onelensupdater")\].resources.requests.memory' "$SRC_FILE" || true)
+assert_ge "$updater_mem_name_selector" "1" "src/patching.sh reads updater memory via name-selector"
+
+###############################################################################
+# Test 21: Sanity guards refuse to patch if image is unexpectedly not deployer/agent
+# If v2.1.65 corrupted a CronJob's image (e.g., dynatrace/oneagent), v2.1.66 must
+# NOT re-apply that corrupted image. Guard greps for expected product name in image.
+###############################################################################
+updater_image_sanity=$(grep -c "UPDATER_IMAGE\".*grep.*'onelens-deployer'" "$SRC_FILE" || true)
+assert_ge "$updater_image_sanity" "1" "src/patching.sh sanity-guards updater image (refuses patch if not onelens-deployer)"
+
+agent_image_sanity=$(grep -c "AGENT_IMAGE\".*grep.*'onelens-agent'" "$SRC_FILE" || true)
+assert_ge "$agent_image_sanity" "1" "src/patching.sh sanity-guards agent image (refuses patch if not onelens-agent)"
+
 test_summary
 exit $?

--- a/tests/test-parity.sh
+++ b/tests/test-parity.sh
@@ -304,5 +304,15 @@ patching_nodes_json=$(grep 'kubectl get nodes' "$ROOT/src/patching.sh" | grep -v
 assert_eq "$install_nodes_json" "0" "install.sh has no kubectl get nodes -o json (OOM risk)"
 assert_eq "$patching_nodes_json" "0" "patching.sh has no kubectl get nodes -o json (OOM risk)"
 
+# ---------------------------------------------------------------------------
+# Test 35: Neither script reads container image via containers[0].image
+# Both scripts must use jsonpath name-selector to survive sidecar injectors
+# (Dynatrace, Istio) that insert containers at index 0. v2.1.65 regression.
+# ---------------------------------------------------------------------------
+install_image_idx0=$(grep -v '^[[:space:]]*#' "$ROOT/install.sh" | grep -c 'containers\[0\]\.image' || true)
+patching_image_idx0=$(grep -v '^[[:space:]]*#' "$ROOT/src/patching.sh" | grep -c 'containers\[0\]\.image' || true)
+assert_eq "$install_image_idx0" "0" "install.sh has no containers[0].image reads (sidecar safety)"
+assert_eq "$patching_image_idx0" "0" "patching.sh has no containers[0].image reads (sidecar safety)"
+
 test_summary
 exit $?

--- a/tests/test-usage-math.sh
+++ b/tests/test-usage-math.sh
@@ -162,5 +162,13 @@ assert_eq "$(calculate_oom_response_memory "400Mi" 4800)" "800Mi" \
     "calculate_oom_response_memory default: 400Mi → 800Mi (2x)"
 
 ###############################################################################
+# v2.1.66: agent memory cap raised to 8192Mi
+# Previous cap (4096Mi) was insufficient — 5 customer clusters were OOMing at
+# the cap. Agent memory scales with metric cardinality/cost data volume, not
+# just pod count. Raised to match Prometheus server cap.
+###############################################################################
+assert_eq "$_USAGE_CAP_AGENT_MEM" "8192" \
+    "_USAGE_CAP_AGENT_MEM raised to 8192 (from 4096) in v2.1.66"
+
 test_summary
 exit $?


### PR DESCRIPTION
## Summary

Two fixes in one PR.

### 1. CronJob image read — sidecar safety (CRITICAL v2.1.65 regression)
v2.1.65 introduced `containers[0].image` jsonpath reads. On clusters with sidecar injectors (e.g. Dynatrace, Istio), a sidecar lands at index 0 → script reads the sidecar image → strategic-merge patch overwrites onelensupdater's image with the sidecar's image → CronJob pod fails to start → silent death. **9 customer clusters silenced.**

Fix: image reads that feed into kubectl patches now use `containers[?(@.name=="X")].image` name-selector. Sanity guards refuse to patch if the image doesn't contain `onelens-deployer` / `onelens-agent`, preventing re-corruption on already-damaged clusters.

### 2. Agent memory cap raised 4096Mi → 8192Mi
Fleet analysis found multiple clusters OOMing at the 4GB cap with `Agent OOMKilled but already at memory cap`. Agent memory scales with metric cardinality/cost data volume, not just pod count. New cap matches Prometheus server cap. Next OOM bumps these clusters 4096Mi → 6144Mi, giving them headroom to recover.

## Files changed
- `src/patching.sh` — name-selector + sanity guards (updater CPU/mem/image reads, agent image read)
- `install.sh` — name-selector for `MY_IMAGE` + substring fallback
- `lib/resource-sizing.sh` — `_USAGE_CAP_AGENT_MEM` 4096 → 8192
- `tests/test-build.sh` — 8 new assertions (Tests 19, 20, 21)
- `tests/test-airgapped.sh` — 3 new assertions (Test 28)
- `tests/test-parity.sh` — 2 new assertions (Test 35)
- `tests/test-usage-math.sh` — 1 new assertion

## Post-release remediation
v2.1.66 cannot self-heal the clusters corrupted by v2.1.65 — their CronJob pod can't run at all. Manual intervention required per affected cluster: either `kubectl patch` to reset the image or deployer chart reinstall by support team.

## Test plan
- [x] Full suite: 764 passed, 0 failed (14 new assertions)
- [x] `--dry-run=server` kubectl patch on test cluster: updater + agent both succeed
- [x] Multi-container simulation: name-selector returns correct image even with sidecar at index 0
- [x] Sanity guard: correctly refuses Dynatrace-corrupted image, accepts air-gapped private registry, accepts healthy image, skips empty
- [x] Agent cap progression verified: 4096→6144, 6144→8192, 8192→8192 (caller logs manual investigation)
- [ ] Post-release validation on test cluster (patch to v2.1.66, verify heartbeat)