### PR TITLE
fix: strategic patch for containers, usage-based agent sizing, stuck-Job cleanup

### DIFF
--- a/src/patching.sh
+++ b/src/patching.sh
@@ -242,7 +242,11 @@ if [ "$NEED_CPU_PATCH" = "true" ] || [ "$NEED_MEM_PATCH" = "true" ]; then
         echo "       Manual recovery required — contact support to reset the CronJob image."
     else
         echo "Updating CronJob resources (cpu=${CURRENT_CPU:-?}→${TARGET_CPU_MILLICORES}m, mem=${CURRENT_MEM:-?}→${TARGET_MEMORY_MI}Mi)..."
-        kubectl patch cronjob onelensupdater -n onelens-agent --type='merge' --field-manager='Helm' -p="{
+        # MUST use --type='strategic' (not 'merge') for container-array patches.
+        # JSON Merge Patch (--type=merge) treats arrays as opaque and REPLACES the
+        # entire containers list, stripping env, command, args, volumeMounts — any
+        # field not in the patch. Strategic Merge Patch merges by container name.
+        kubectl patch cronjob onelensupdater -n onelens-agent --type='strategic' --field-manager='Helm' -p="{
           \"spec\":{\"jobTemplate\":{\"spec\":{\"template\":{\"spec\":{\"containers\":[{
             \"name\":\"onelensupdater\",
             \"image\":\"$UPDATER_IMAGE\",
@@ -902,6 +906,15 @@ if [ -n "$PROM_SVC" ]; then
         PROMETHEUS_PUSHGATEWAY_MEMORY_REQUEST="$NEW_PGW_MEM"
         PROMETHEUS_PUSHGATEWAY_MEMORY_LIMIT="$NEW_PGW_MEM"
 
+        # Evaluate: Agent (CronJob — runs hourly, but Prometheus captures memory
+        # during each run's window). This replaces the heuristic-based Strategy 2
+        # (Job-history fallback) that was prone to false-positive bumps.
+        _evaluate_and_log "onelens-agent" "onelens-agent" \
+            "$ONELENS_MEMORY_LIMIT" "$ONELENS_CPU_LIMIT" \
+            "$_USAGE_FLOOR_AGENT_MEM" "$_USAGE_CAP_AGENT_MEM" "NEW_AGENT_OOM"
+        ONELENS_MEMORY_REQUEST="$_OUT_MEM"; ONELENS_MEMORY_LIMIT="$_OUT_MEM"
+        ONELENS_CPU_REQUEST="$_OUT_CPU"; ONELENS_CPU_LIMIT="$_OUT_CPU"
+
         # Summary
         if [ "$SIZING_CHANGES" -gt 0 ]; then
             echo "Usage-based sizing: $SIZING_CHANGES component(s) adjusted"
@@ -958,31 +971,14 @@ if [ -n "$_agent_oom_pod" ]; then
     fi
 fi
 
-# Strategy 2: if live-pod check found nothing, consult Job history.
-# Count recent agent Jobs (last 5) that failed with BackoffLimitExceeded —
-# the hallmark of pods repeatedly crashing until the Job gives up. This works
-# even after failed pods have been GC'd, because the Job resource retains
-# its failed count and conditions.
-if [ -z "$_agent_bump_reason" ]; then
-    # grep -c always emits a count to stdout (even on no match); just trust it
-    # and default to 0 if pipeline returns empty. The earlier `|| echo "0"`
-    # pattern would APPEND a second "0" line because grep -c outputs "0" then
-    # exits 1, triggering the fallback — yielding the literal string "0\n0".
-    _agent_failed_jobs=$(kubectl get jobs -n onelens-agent --no-headers 2>/dev/null \
-        | grep -E '^onelens-agent-[0-9]' | tail -5 | grep -c 'Failed' 2>/dev/null)
-    _agent_failed_jobs=${_agent_failed_jobs:-0}
-    # Also look for OOMKilling events within the last window — retained even
-    # when pods are gone. Presence is corroborating evidence, not required.
-    _agent_oom_events=$(kubectl get events -n onelens-agent --no-headers 2>/dev/null \
-        | grep -iE 'OOMKill|OOMKilling' | grep -c 'onelens-agent-' 2>/dev/null)
-    _agent_oom_events=${_agent_oom_events:-0}
-    if [ "$_agent_failed_jobs" -ge 2 ] 2>/dev/null; then
-        _agent_bump_reason="chronic Job failures (GC'd pods)"
-        _agent_bump_evidence="failed_jobs=${_agent_failed_jobs}/5 oom_events=${_agent_oom_events}"
-    fi
-fi
+# Strategy 2 (Job-history fallback) removed in v2.1.68.
+# It caused false-positive bumps on 35+ clusters by counting historical Job failures
+# (not just current ones). Agent memory is now sized by the usage-based evaluation
+# engine (Prometheus container_memory_working_set_bytes over 72h), same as
+# Prometheus/KSM/OpenCost. Strategy 1 (live-pod OOM above) is kept for immediate
+# OOM response — usage-based handles steady-state right-sizing.
 
-# Apply the bump (same logic for both strategies)
+# Apply the bump (Strategy 1 only — live-pod OOM detection)
 if [ -n "$_agent_bump_reason" ]; then
     _agent_cur_mi=$(_memory_to_mi "$ONELENS_MEMORY_LIMIT")
     if [ "$_agent_cur_mi" -ge "$_USAGE_CAP_AGENT_MEM" ] 2>/dev/null; then
@@ -2437,30 +2433,40 @@ if [ -n "$AGENT_CJ_EXISTS" ]; then
             echo "Agent CronJob backoffLimit patched" || echo "WARNING: Failed to patch agent backoffLimit"
     fi
 
-    # Check for agent pods stuck in Pending/ContainerCreating (volume attach, image pull, scheduling)
-    AGENT_STUCK_POD=$(kubectl get pods -n onelens-agent --no-headers 2>/dev/null \
-        | grep -E "$AGENT_POD_PATTERN" \
-        | awk '$3 == "Pending" || $3 == "ContainerCreating" {print $1; exit}' || true)
-    if [ -n "$AGENT_STUCK_POD" ]; then
-        AGENT_STUCK_AGE=$(kubectl get pod "$AGENT_STUCK_POD" -n onelens-agent \
-            -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || true)
-        AGENT_STUCK_SECS=""
-        if [ -n "$AGENT_STUCK_AGE" ]; then
-            AGENT_STUCK_SECS=$(seconds_since "$AGENT_STUCK_AGE")
+    # Clean up stuck/orphaned agent Jobs that block concurrencyPolicy: Forbid.
+    # With Forbid, the CronJob won't create a new Job while any previous Job is
+    # "active". An active Job whose pod is stuck (Pending, ImagePullBackOff, etc.)
+    # or whose pod was GC'd (orphaned Job) creates a permanent deadlock.
+    # The old code (v2.1.67) only checked for pods in Pending/ContainerCreating —
+    # missed ImagePullBackOff/Init states and orphaned Jobs entirely. This version
+    # checks Jobs first (via .status.active), then inspects the pod state. It
+    # deletes the JOB (not just the pod) to definitively clear the deadlock.
+    # NEVER deletes a Job whose pod is Running — safe for 30-45 min agent runs.
+    _active_agent_jobs=$(kubectl get jobs -n onelens-agent \
+        -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.active}{"\n"}{end}' 2>/dev/null \
+        | grep -E "^${AGENT_CJ_NAME}-[0-9]+ [1-9]" | awk '{print $1}' || true)
+    for _stuck_job in $_active_agent_jobs; do
+        _job_pod_line=$(kubectl get pods -n onelens-agent -l "job-name=$_stuck_job" --no-headers 2>/dev/null | head -1 || true)
+        _pod_name=$(echo "$_job_pod_line" | awk '{print $1}')
+        _pod_status=$(echo "$_job_pod_line" | awk '{print $3}')
+        if [ -z "$_job_pod_line" ]; then
+            echo "Orphaned agent Job $_stuck_job (no pod) — deleting to unblock CronJob"
+            kubectl delete job "$_stuck_job" -n onelens-agent 2>/dev/null || true
+        elif [ "$_pod_status" = "Running" ] || [ "$_pod_status" = "Completed" ]; then
+            : # Pod is healthy or done — leave alone
+        else
+            # Pod is in a stuck state (Pending, ImagePullBackOff, Init:*, ErrImagePull, etc.)
+            _pod_age_ts=$(kubectl get pod "$_pod_name" -n onelens-agent \
+                -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || true)
+            _pod_age_secs=$(seconds_since "$_pod_age_ts" 2>/dev/null || echo "0")
+            if [ "$_pod_age_secs" -gt 600 ] 2>/dev/null; then
+                echo "Agent Job $_stuck_job stuck (pod=$_pod_name status=$_pod_status age=${_pod_age_secs}s) — deleting Job to unblock CronJob"
+                kubectl delete job "$_stuck_job" -n onelens-agent 2>/dev/null || true
+            else
+                echo "WARNING: Agent Job $_stuck_job pod=$_pod_name status=$_pod_status age=${_pod_age_secs}s — waiting (< 10 min threshold)"
+            fi
         fi
-        AGENT_STUCK_EVENTS=$(kubectl get events -n onelens-agent --field-selector "involvedObject.name=$AGENT_STUCK_POD" --no-headers 2>/dev/null | tail -5 || true)
-        echo "WARNING: Agent pod stuck: $AGENT_STUCK_POD (${AGENT_STUCK_SECS:-?}s)"
-        if [ -n "$AGENT_STUCK_EVENTS" ]; then
-            echo "--- Agent stuck pod events ---"
-            echo "$AGENT_STUCK_EVENTS"
-            echo "--- end ---"
-        fi
-        # Delete if stuck > 10 min (hourly CronJob, can't afford to wait)
-        if [ -n "$AGENT_STUCK_SECS" ] && [ "$AGENT_STUCK_SECS" -gt 600 ] 2>/dev/null; then
-            echo "Agent pod stuck > 10 min — deleting to unblock CronJob"
-            kubectl delete pod "$AGENT_STUCK_POD" -n onelens-agent --grace-period=0 2>/dev/null || true
-        fi
-    fi
+    done
 
     # Check recent agent Job pods (last 3 jobs)
     AGENT_JOBS=$(kubectl get jobs -n onelens-agent --no-headers 2>/dev/null \
@@ -2558,7 +2564,8 @@ if [ -n "$AGENT_CJ_EXISTS" ]; then
                             echo "       Previous state: AGENT_CPU_LIMIT=${AGENT_CPU_LIMIT:-unset}"
                             echo "       May indicate CronJob corruption. Manual recovery required — contact support."
                         else
-                            _agent_cpu_patch_err=$(kubectl patch cronjob "$AGENT_CJ_NAME" -n onelens-agent --type='merge' --field-manager='Helm' -p="{
+                            # MUST use --type='strategic' — see updater patch comment.
+                            _agent_cpu_patch_err=$(kubectl patch cronjob "$AGENT_CJ_NAME" -n onelens-agent --type='strategic' --field-manager='Helm' -p="{
                               \"spec\":{\"jobTemplate\":{\"spec\":{\"template\":{\"spec\":{\"containers\":[{
                                 \"name\":\"$AGENT_CONTAINER_NAME\",
                                 \"image\":\"$AGENT_IMAGE\",

--- a/tests/test-build.sh
+++ b/tests/test-build.sh
@@ -297,21 +297,20 @@ agent_oom_bad_assign=$(grep -E '_agent_term=\$\(kubectl' "$SRC_FILE" | grep -c '
 assert_eq "$agent_oom_bad_assign" "0" "src/patching.sh _agent_term assignment does not use containerStatuses[0]"
 
 ###############################################################################
-# Test 25: Agent OOM pre-helm detection has a Job-history fallback
-# On clusters with infrequent agent schedule (e.g., hourly), failed agent pods
-# get GC'd between runs, so the live-pod check misses them. v2.1.67 adds a
-# fallback that inspects kubectl get jobs for BackoffLimitExceeded / Failed
-# state, so auto-bump can fire even when no OOMed pod is currently visible.
+# Test 25: Strategy 2 (Job-history fallback) REMOVED in v2.1.68
+# It caused false-positive memory bumps on 35+ clusters. Agent memory is now
+# sized by the usage-based evaluation engine (Prometheus data), same as
+# Prometheus/KSM/OpenCost. Strategy 1 (live-pod OOM) is kept.
 ###############################################################################
-agent_fallback_jobs=$(grep -cE 'kubectl get jobs.*onelens-agent|_agent_failed_jobs' "$SRC_FILE" || true)
-assert_ge "$agent_fallback_jobs" "1" "src/patching.sh has Job-history fallback for agent OOM detection"
+strategy2_removed=$(grep -c '_agent_failed_jobs' "$SRC_FILE" || true)
+assert_eq "$strategy2_removed" "0" "src/patching.sh Strategy 2 (Job-history fallback) removed — no _agent_failed_jobs"
 
-agent_fallback_reason=$(grep -c '_agent_bump_reason' "$SRC_FILE" || true)
-assert_ge "$agent_fallback_reason" "3" "src/patching.sh agent OOM detection logs which strategy fired (live-pod vs job-history)"
+agent_usage_based=$(grep -c '_evaluate_and_log.*onelens-agent' "$SRC_FILE" || true)
+assert_ge "$agent_usage_based" "1" "src/patching.sh agent added to usage-based evaluation engine"
 
-# Bump threshold guard — ensure we require 2+ failed jobs (not 1), to reduce false positives
-agent_threshold=$(grep -c '_agent_failed_jobs.*-ge 2' "$SRC_FILE" || true)
-assert_ge "$agent_threshold" "1" "src/patching.sh agent Job-history fallback requires 2+ failed jobs"
+# Strategy 1 (live-pod OOM) is still present
+agent_strategy1=$(grep -c '_agent_bump_reason' "$SRC_FILE" || true)
+assert_ge "$agent_strategy1" "3" "src/patching.sh Strategy 1 (live-pod OOM) still present"
 
 ###############################################################################
 # Test 26: All other failed-pod / terminated.reason reads use name-selector
@@ -341,6 +340,44 @@ assert_ge "$agent_posthelm_exitcode_selector" "1" "src/patching.sh post-helm age
 # Only comments may reference the pattern (for documentation).
 active_containers_idx0=$(grep -v '^[[:space:]]*#' "$SRC_FILE" | grep -cE 'containers\[0\]\.(image|name|resources|restartCount)|containerStatuses\[0\]\.(state|lastState|restartCount)' || true)
 assert_eq "$active_containers_idx0" "0" "src/patching.sh has no active containers[0]/containerStatuses[0] reads in image/status/resource paths"
+
+###############################################################################
+# Test 27: Container-array kubectl patches use --type='strategic' (not 'merge')
+# JSON Merge Patch (--type=merge) treats arrays as opaque — REPLACES the entire
+# containers list, stripping env, command, args, volumeMounts. Strategic Merge
+# Patch merges by container name, preserving unspecified fields.
+# v2.1.65-v2.1.67 used --type=merge which caused browserstack-euc1-stag-001's
+# deployment_type env var to be stripped → entrypoint.sh crash.
+###############################################################################
+# Positive: --type='strategic' on container patches (multiline commands — check
+# that the line with --type='strategic' is a kubectl patch cronjob line)
+strategic_count=$(grep -c "type='strategic'" "$SRC_FILE" || true)
+assert_ge "$strategic_count" "2" "src/patching.sh has at least 2 --type='strategic' patches (updater + agent)"
+
+# Negative: no --type='merge' on kubectl patch lines that are near containers
+# (container patches are multiline; check that no kubectl patch with containers
+# nearby uses --type='merge' by checking the MUST-use-strategic comment is present)
+strategic_comment=$(grep -c "MUST use --type='strategic'" "$SRC_FILE" || true)
+assert_ge "$strategic_comment" "2" "src/patching.sh has MUST-use-strategic comments on both container patches"
+
+###############################################################################
+# Test 28: Stuck-Job cleanup uses Job-first detection (not pod-first)
+# v2.1.67 only checked pods (missed orphaned Jobs, ImagePullBackOff, Init:*).
+# v2.1.68 queries Jobs via .status.active, then checks pod via job-name label.
+# Deletes the JOB (not pod) to definitively unblock concurrencyPolicy:Forbid.
+###############################################################################
+stuck_job_label_selector=$(grep -c 'job-name=\$_stuck_job' "$SRC_FILE" || true)
+assert_ge "$stuck_job_label_selector" "1" "src/patching.sh stuck-Job cleanup uses job-name label to find pods"
+
+stuck_job_delete=$(grep -v '^[[:space:]]*#' "$SRC_FILE" | grep -c 'kubectl delete job.*_stuck_job' || true)
+assert_ge "$stuck_job_delete" "1" "src/patching.sh deletes stuck JOB (not pod) to unblock CronJob"
+
+orphan_detection=$(grep -c 'Orphaned agent Job' "$SRC_FILE" || true)
+assert_ge "$orphan_detection" "1" "src/patching.sh detects orphaned Jobs (no pod) for cleanup"
+
+# Old pod-deletion pattern removed
+old_stuck_pod_delete=$(grep -c 'kubectl delete pod.*AGENT_STUCK_POD' "$SRC_FILE" || true)
+assert_eq "$old_stuck_pod_delete" "0" "src/patching.sh old pod-deletion stuck cleanup removed"
 
 test_summary
 exit $?


### PR DESCRIPTION
## Summary — three fixes for v2.1.68

### 1. CRITICAL: --type='merge' → --type='strategic' on container-array patches

JSON Merge Patch (`--type=merge`) treats arrays as opaque — REPLACES the entire `containers` list with what's in the patch body, stripping `env`, `command`, `args`, `volumeMounts`. Strategic Merge Patch (`--type=strategic`) merges by container `name`, preserving unspecified fields.

This caused `deployment_type` env var to be stripped from the updater CronJob on clusters where the resource patch actually fired (CPU below 200m target). `entrypoint.sh` then crashes with "Unrecognized deployment_type:" because the routing env var is gone.

Before v2.1.65: patches always FAILED silently (missing image field) → env was never touched. v2.1.65 fixed the image field → patches started succeeding → JSON Merge Patch strips env on every successful patch.

Verified via `--dry-run=server` on live cluster: `--type=merge` strips env, `--type=strategic` preserves it.

### 2. Agent added to usage-based evaluation engine (replaces Strategy 2)

Strategy 2 (Job-history fallback, added in v2.1.67) caused false-positive memory bumps on 35+ clusters — some bumped to 8192Mi (17x over-provisioned). Root cause: threshold "2+ failed Jobs in last 5" caught historical failures, not current ones.

Agent memory is now sized by the same Prometheus-data-driven engine used for Prometheus/KSM/OpenCost:
- Queries `max(container_memory_working_set_bytes{container="onelens-agent"}[72h])`
- Applies 1.35x buffer, clamps between floor and cap
- Full eval every 72h: CAN downsize (max 50% per step — safe-downsize guard)
- Normal 5-min checks: upsize only
- OOM hold: 7-day window after OOM, no downsize
- No new Prometheus queries needed — `$MEM_72H`/`$CPU_72H` already have the data

Over-provisioned clusters will gradually step down to right-sized values over ~15 days (50% per 72h). No OOM risk at any step.

Strategy 1 (live-pod OOM detection for immediate response) is kept.

### 3. Stuck-Job cleanup (replaces pod-only detection)

Old code only checked for pods in `Pending`/`ContainerCreating`. Missed:
- `ImagePullBackOff`, `ErrImagePull`, `Init:*` stuck states
- Orphaned Jobs (pod GC'd but Job still active) → permanent `concurrencyPolicy: Forbid` deadlock

New code queries active Jobs via `.status.active` jsonpath, finds pods via `job-name` label selector. Handles orphaned Jobs (no pod found), expanded stuck states. Deletes the **Job** (not pod) to definitively unblock CronJob. Never touches Running pods — safe for 30-45 min agent collection runs.

## Test plan
- [x] Full suite: 787 passed, 0 failed (10 new/updated assertions in Tests 25, 27, 28)
- [x] Fix 1: `--dry-run=server` confirms `--type=strategic` preserves env vars
- [x] Fix 2: Prometheus returns agent peak 72h memory (84Mi on test cluster — data available)
- [x] Fix 3: `job-name` label selector finds correct pod; `.status.active` jsonpath works
- [ ] Post-release: monitor over-provisioned clusters stepping down; verify no OOM regressions