### PR TITLE
fix: gross over-provisioning override + staleness-aware agent trigger

### DIFF
--- a/lib/resource-sizing.sh
+++ b/lib/resource-sizing.sh
@@ -430,6 +430,35 @@ evaluate_container_sizing() {
     proposed_mem=$(calculate_usage_memory "$max_mem_bytes" "$mem_buffer" "$mem_floor" "$mem_cap")
     proposed_cpu=$(calculate_usage_cpu "$max_cpu_cores" "$cpu_buffer" "$cpu_floor" "$cpu_cap")
 
+    # Gross over-provisioning override: if current memory is more than 3x what
+    # Prometheus data suggests (with buffer), force a downsize even on 5-min
+    # checks — don't wait for the 72h full-eval cycle. This catches components
+    # that were false-bumped or newly added to the evaluation engine. The 50%
+    # safe-downsize guard still applies: if proposed < 50% of current, cut to
+    # 50% of current (rounded to nearest 100Mi). Multiple cycles converge.
+    if [ -n "$proposed_mem" ]; then
+        local _gop_cur_mi _gop_prop_mi
+        _gop_cur_mi=$(_memory_to_mi "$current_mem")
+        _gop_prop_mi=$(_memory_to_mi "$proposed_mem")
+        if [ "$_gop_cur_mi" -gt 0 ] && [ "$_gop_prop_mi" -gt 0 ] && \
+           [ "$_gop_cur_mi" -gt $((_gop_prop_mi * 3)) ] 2>/dev/null; then
+            if is_safe_downsize "$proposed_mem" "$current_mem"; then
+                new_mem="$proposed_mem"
+            else
+                # Proposed is < 50% of current. Cut to 50% (rounded to 100Mi).
+                local _half_mi=$(( (_gop_cur_mi / 2 + 99) / 100 * 100 ))
+                new_mem="${_half_mi}Mi"
+            fi
+            # CPU: also allow adjustment on gross override
+            if [ -n "$proposed_cpu" ]; then
+                new_cpu="$proposed_cpu"
+            fi
+            echo "MEM=$new_mem"
+            echo "CPU=$new_cpu"
+            return 0
+        fi
+    fi
+
     if [ "$is_full_eval" = "true" ]; then
         # Full 72h evaluation: can go up OR down
         if [ -n "$proposed_mem" ]; then

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -2637,6 +2637,24 @@ if [ -n "$AGENT_CJ_EXISTS" ]; then
         _should_trigger=true
     elif [ -z "$AGENT_LAST_SUCCESS" ]; then
         _should_trigger=true
+    else
+        # Staleness check: if the last successful agent Job completed > 2 hours ago,
+        # the agent is stale. The hourly CronJob should have produced a newer success
+        # but didn't — likely silent failures (OOM, scheduling, ResourceQuota).
+        # Trigger an immediate manual run to recover data freshness.
+        _last_success_job=$(kubectl get jobs -n onelens-agent --no-headers 2>/dev/null \
+            | grep -E "$AGENT_POD_PATTERN" | grep 'Complete' | tail -1 | awk '{print $1}' || true)
+        if [ -n "$_last_success_job" ]; then
+            _last_success_ts=$(kubectl get job "$_last_success_job" -n onelens-agent \
+                -o jsonpath='{.status.completionTime}' 2>/dev/null || true)
+            if [ -n "$_last_success_ts" ]; then
+                _last_success_secs=$(seconds_since "$_last_success_ts" 2>/dev/null || echo "0")
+                if [ "$_last_success_secs" -gt 7200 ] 2>/dev/null; then
+                    _should_trigger=true
+                    echo "Agent data stale (last success ${_last_success_secs}s ago > 2h threshold)"
+                fi
+            fi
+        fi
     fi
 
     if [ "$_should_trigger" = "true" ]; then

--- a/tests/test-evaluation-engine.sh
+++ b/tests/test-evaluation-engine.sh
@@ -52,11 +52,12 @@ assert_eq "$(_eval_cpu "prom" "420Mi" "150m" "200000000" "0.08" "false" "false" 
 # 72h full evaluation (can downsize)
 ###############################################################################
 
-# Downsize: safety guard limits to max 50% reduction per cycle
-# 200MB * 1.35 = 258Mi, current = 1771Mi. 258Mi < 886Mi (50% of 1771) → blocked by safety guard
-# This is correct: severely over-provisioned clusters downsize gradually (50% per 72h cycle)
+# Downsize: gross over-provisioning override (v2.1.69)
+# 200MB * 1.35 = 258Mi, current = 1771Mi. 1771/258 = 6.9x → exceeds 3x threshold.
+# Override fires: proposed 258 < 50% of 1771 (886) → cut to 50% = 886 → rounded to 900Mi.
+# Before v2.1.69 this was blocked ("keep current"), now it forces a 50% step-down per cycle.
 assert_eq "$(_eval_mem "prom" "1771Mi" "150m" "200000000" "0.08" "false" "false" "true" "false" 1.35 1.25 150 4800 50 1200)" \
-    "1771Mi" "72h eval: safety guard limits severe downsize (258Mi < 50% of 1771Mi)"
+    "900Mi" "gross over-provision: 1771Mi → 900Mi (50% cut, 6.9x over actual usage)"
 
 # Moderate downsize allowed: within 50% safety guard
 # 400MB * 1.35 = 515Mi raw → rounded to 600Mi, current = 720Mi. 600Mi >= 360Mi (50% of 720) → allowed
@@ -68,10 +69,22 @@ assert_eq "$(_eval_mem "prom" "720Mi" "150m" "400000000" "0.08" "false" "false" 
 assert_eq "$(_eval_mem "prom" "720Mi" "150m" "1500000000" "0.08" "false" "false" "true" "false" 1.35 1.25 150 4800 50 1200)" \
     "2000Mi" "72h eval: upsize (2000Mi from 720Mi)"
 
-# Safety guard: refuse if new < 50% of current
+# Safety guard: refuse if new < 50% of current (NOT gross — 400/150 = 2.7x < 3x threshold)
 # 50MB * 1.35 = 65Mi → below floor 150Mi. 150Mi < 50% of 400Mi (200Mi) → blocked
+# Gross override doesn't fire (2.7x < 3x) → normal full-eval safety guard blocks.
 assert_eq "$(_eval_mem "prom" "400Mi" "150m" "50000000" "0.08" "false" "false" "true" "false" 1.35 1.25 150 4800 50 1200)" \
-    "400Mi" "72h eval: safety guard blocks (150Mi < 200Mi = 50% of 400Mi)"
+    "400Mi" "72h eval: safety guard blocks (150Mi < 200Mi = 50% of 400Mi, 2.7x < 3x)"
+
+# Gross over-provisioning on 5-min check (NOT full eval): forces downsize
+# 84MB * 1.35 = 108Mi → floor 384Mi. Current 8192Mi / 384Mi = 21x → override fires.
+# 384 < 50% of 8192 (4096) → cut to 50% = 4096 → rounded to 4100Mi.
+assert_eq "$(_eval_mem "test" "8192Mi" "600m" "88080384" "0.1" "false" "false" "false" "false" 1.35 1.25 384 8192 50 1200)" \
+    "4100Mi" "5-min gross override: 8192Mi → 4100Mi (50% cut, 21x over usage)"
+
+# Not grossly over-provisioned on 5-min (2x): normal upsize-only → no change
+# 400MB * 1.35 = 515Mi → floor stays at 515Mi. Current 800Mi / 515Mi = 1.6x < 3x → no override.
+assert_eq "$(_eval_mem "test" "800Mi" "200m" "419430400" "0.1" "false" "false" "false" "false" 1.35 1.25 384 8192 50 1200)" \
+    "800Mi" "5-min no override: 800Mi stays (1.6x < 3x threshold)"
 
 # CPU downsize on 72h eval
 # 0.04 cores * 1.25 = 50m, current = 150m → downsize to 50m


### PR DESCRIPTION
## Summary — two fixes for v2.1.69

### 1. Gross over-provisioning override (lib/resource-sizing.sh)

Adds a new priority step in `evaluate_container_sizing()`: on ANY check (5-min or 72h), if current memory > 3x what Prometheus usage data suggests (with buffer), force a downsize with the 50% safe-downsize guard. Don't wait for the 72h full-eval cycle.

This catches components that were false-bumped or newly added to the evaluation engine and couldn't downsize until the next 72h cycle. Now they step down immediately via 50% cuts per cycle until within the 3x threshold.

Safety: OOM hold (7-day), first-run hold, and no-data hold all return BEFORE the override check. Only fires with valid Prometheus data proving gross waste. Applies to ALL components.

### 2. Staleness-aware agent manual trigger (src/patching.sh)

If the last completed agent Job finished > 2 hours ago, trigger an immediate manual run. The existing code only triggered when failed pods existed or zero completed jobs were found — missed the "stale success" case where the most recent completed job was hours old while subsequent jobs failed silently.

Uses `completionTime` via jsonpath + `seconds_since()` for reliable age calculation.

## Test plan
- [x] Full suite: 789 passed, 0 failed (3 updated/new assertions in test-evaluation-engine.sh)
- [x] Fix 1: 5 scenarios validated on live cluster (override fires, correctly sized untouched, OOM hold blocks, no-data holds)
- [x] Fix 2: `seconds_since(completionTime)` verified on live cluster
- [ ] Post-release: monitor over-provisioned clusters stepping down; verify agent data freshness improves