### PR TITLE
docs: scope helm repo update to onelens in example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Your Kubernetes clusters are automatically discovered and visible in the OneLens
 
 ```bash
 helm repo add onelens https://astuto-ai.github.io/onelens-installation-scripts/ && \
-helm repo update && \
+helm repo update onelens && \
 helm upgrade --install onelensdeployer onelens/onelensdeployer \
   -n onelens-agent --create-namespace \
   --set job.env.CLUSTER_NAME=<cluster-name> \
@@ -372,7 +372,7 @@ Apply custom labels to OneLens resources. Useful for organizational policies tha
 To upgrade to a newer version:
 
 ```bash
-helm repo update
+helm repo update onelens
 helm upgrade onelensdeployer onelens/onelensdeployer \
   -n onelens-agent --reuse-values
 ```

--- a/docs/airgapped-deployment-guide.md
+++ b/docs/airgapped-deployment-guide.md
@@ -210,7 +210,7 @@ Run the standard OneLens install command, pointing to your private registry inst
 **Standard install (for reference):**
 
 ```bash
-helm repo add onelens https://astuto-ai.github.io/onelens-installation-scripts/ && helm repo update
+helm repo add onelens https://astuto-ai.github.io/onelens-installation-scripts/ && helm repo update onelens
 helm upgrade --install onelensdeployer onelens/onelensdeployer \
   -n onelens-agent --create-namespace \
   --set job.env.CLUSTER_NAME=<cluster-name> \

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -38,7 +38,7 @@ gh release create v1.2.3 --title "Release v1.2.3" --notes "Release notes here"
 #### List Available Helm Charts
 ```bash
 helm repo add onelens https://astuto-ai.github.io/onelens-installation-scripts/
-helm repo update
+helm repo update onelens
 helm search repo onelens --versions --devel
 ```
 


### PR DESCRIPTION
## Summary
- Updates 4 example commands across README.md, docs/quick-reference.md, and docs/airgapped-deployment-guide.md
- Changes `helm repo update` → `helm repo update onelens` in install, upgrade, chart listing, and airgapped-install examples
- Avoids failures on customer clusters when unrelated helm repos are unreachable (e.g., decommissioned internal repos)
- Both `onelens-agent` and `onelensdeployer` charts live in the same `onelens` repo, so the scoped form refreshes both

## Test plan
- [ ] Verify rendered README renders correctly on GitHub
- [ ] Confirm `helm repo update onelens` works equivalently to `helm repo update` for our use case