### PR TITLE
feat(gpu): Phase 1 GPU monitoring detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -372,8 +372,14 @@ LABEL_MULTIPLIER=$(get_label_multiplier "$AVG_LABELS")
 echo "Label density: $AVG_LABELS (default), multiplier: ${LABEL_MULTIPLIER}x"
 
 # --- GPU node detection ---
+# No Prometheus at install time (it's deployed as part of this install).
+# First patching run (5 min after install) performs the Prometheus PROF metric check.
 GPU_NODE_COUNT=0
 TOTAL_GPU_COUNT=0
+GPU_MONITORING_STATUS="not_applicable"
+DCGM_PODS_OURS=0
+DCGM_PODS_OTHER=0
+DCGM_PODS_TOTAL=0
 gpu_capacities=$(kubectl get nodes --chunk-size=100 -o custom-columns='GPU:.status.capacity.nvidia\.com/gpu' --no-headers 2>/dev/null || true)
 if [ -n "$gpu_capacities" ]; then
     GPU_NODE_COUNT=$(echo "$gpu_capacities" | awk '$1 != "<none>" && $1+0 > 0 {c++} END {print c+0}')
@@ -381,12 +387,20 @@ if [ -n "$gpu_capacities" ]; then
 fi
 if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     echo "GPU nodes: $GPU_NODE_COUNT nodes, $TOTAL_GPU_COUNT GPUs total"
-    dcgm_pods=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | wc -l | tr -d '[:space:]')
-    if [ "$dcgm_pods" -eq 0 ] 2>/dev/null; then
+    GPU_MONITORING_STATUS="cost_only"
+    DCGM_PODS_OURS=$(kubectl get pods -n onelens-agent -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | wc -l | tr -d '[:space:]')
+    DCGM_PODS_OTHER=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    DCGM_PODS_TOTAL=$((DCGM_PODS_OURS + DCGM_PODS_OTHER))
+    if [ "$DCGM_PODS_TOTAL" -eq 0 ] 2>/dev/null; then
         echo "WARNING: GPU nodes found but NVIDIA DCGM exporter not detected — GPU utilization metrics unavailable"
+        echo "  GPU cost (gpuCount, gpuHours, gpuCost) works without DCGM."
+        echo "  GPU utilization (gpuUsageAverage, gpuUsageMax, gpuEfficiency) requires DCGM exporter."
+    elif [ "$DCGM_PODS_OTHER" -gt 0 ]; then
+        echo "DCGM exporter: $DCGM_PODS_OTHER pods (customer-managed, outside onelens-agent namespace)"
     else
-        echo "NVIDIA DCGM exporter running ($dcgm_pods pods)"
+        echo "DCGM exporter: $DCGM_PODS_OURS pods (in onelens-agent namespace)"
     fi
+    echo "GPU_MONITORING_STATUS=$GPU_MONITORING_STATUS"
 fi
 
 # --- Air-gapped self-detection ---

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -352,9 +352,14 @@ AVG_LABELS=6
 LABEL_MULTIPLIER=$(get_label_multiplier "$AVG_LABELS")
 echo "Label density: $AVG_LABELS (default), multiplier: ${LABEL_MULTIPLIER}x"
 
-# --- GPU node detection ---
+# --- GPU node detection (Stage 1: kubectl only) ---
+# Stage 2 (Prometheus PROF metric check) runs later, after PROM_SVC is available.
 GPU_NODE_COUNT=0
 TOTAL_GPU_COUNT=0
+GPU_MONITORING_STATUS="not_applicable"
+DCGM_PODS_OURS=0
+DCGM_PODS_OTHER=0
+DCGM_PODS_TOTAL=0
 gpu_capacities=$(kubectl get nodes --chunk-size=100 -o custom-columns='GPU:.status.capacity.nvidia\.com/gpu' --no-headers 2>/dev/null || true)
 if [ -n "$gpu_capacities" ]; then
     GPU_NODE_COUNT=$(echo "$gpu_capacities" | awk '$1 != "<none>" && $1+0 > 0 {c++} END {print c+0}')
@@ -362,11 +367,18 @@ if [ -n "$gpu_capacities" ]; then
 fi
 if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     echo "GPU nodes: $GPU_NODE_COUNT nodes, $TOTAL_GPU_COUNT GPUs total"
-    dcgm_pods=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | wc -l | tr -d '[:space:]')
-    if [ "$dcgm_pods" -eq 0 ] 2>/dev/null; then
+    GPU_MONITORING_STATUS="cost_only"
+    DCGM_PODS_OURS=$(kubectl get pods -n onelens-agent -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | wc -l | tr -d '[:space:]')
+    DCGM_PODS_OTHER=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    DCGM_PODS_TOTAL=$((DCGM_PODS_OURS + DCGM_PODS_OTHER))
+    if [ "$DCGM_PODS_TOTAL" -eq 0 ] 2>/dev/null; then
         echo "WARNING: GPU nodes found but NVIDIA DCGM exporter not detected — GPU utilization metrics unavailable"
+        echo "  GPU cost (gpuCount, gpuHours, gpuCost) works without DCGM."
+        echo "  GPU utilization (gpuUsageAverage, gpuUsageMax, gpuEfficiency) requires DCGM exporter."
+    elif [ "$DCGM_PODS_OTHER" -gt 0 ]; then
+        echo "DCGM exporter: $DCGM_PODS_OTHER pods (customer-managed, outside onelens-agent namespace)"
     else
-        echo "NVIDIA DCGM exporter running ($dcgm_pods pods)"
+        echo "DCGM exporter: $DCGM_PODS_OURS pods (in onelens-agent namespace)"
     fi
 fi
 
@@ -932,6 +944,29 @@ if [ -n "$PROM_SVC" ]; then
     else
         echo "Usage-based sizing: no Prometheus data available, keeping tier-based limits"
     fi
+fi
+
+# --- GPU monitoring status (Stage 2: Prometheus check) ---
+# Refines GPU_MONITORING_STATUS from Stage 1 by querying for the specific DCGM
+# metric OpenCost needs for utilization fields. Only runs when GPU nodes exist,
+# DCGM pods were found, and Prometheus is available.
+# _prom_query_raw and PROM_QUERY_URL were defined inside the PROM_SVC block above
+# (bash functions/variables persist in global scope after the block ends).
+if [ "$GPU_NODE_COUNT" -gt 0 ] && [ "$DCGM_PODS_TOTAL" -gt 0 ] 2>/dev/null && [ -n "${PROM_QUERY_URL:-}" ]; then
+    PROF_RAW=$(_prom_query_raw 'count(DCGM_FI_PROF_GR_ENGINE_ACTIVE)')
+    PROF_HAS_DATA=$(echo "$PROF_RAW" | grep -c '"value"' || true)
+    if [ "$PROF_HAS_DATA" -gt 0 ]; then
+        GPU_MONITORING_STATUS="fully_configured"
+        echo "GPU monitoring: fully configured (DCGM_FI_PROF_GR_ENGINE_ACTIVE present in Prometheus)"
+    else
+        GPU_MONITORING_STATUS="dcgm_misconfigured"
+        echo "WARNING: DCGM exporter running but DCGM_FI_PROF_GR_ENGINE_ACTIVE not found in Prometheus"
+        echo "  GPU utilization fields (gpuUsageAverage, gpuUsageMax, gpuEfficiency) will be null."
+        echo "  Fix: set args: [\"-f\", \"/etc/dcgm-exporter/dcp-metrics-included.csv\"] on your DCGM DaemonSet."
+    fi
+fi
+if [ "$GPU_NODE_COUNT" -gt 0 ]; then
+    echo "GPU_MONITORING_STATUS=$GPU_MONITORING_STATUS"
 fi
 
 # --- Agent OOM pre-helm detection ---

--- a/tests/test-parity.sh
+++ b/tests/test-parity.sh
@@ -314,5 +314,55 @@ patching_image_idx0=$(grep -v '^[[:space:]]*#' "$ROOT/src/patching.sh" | grep -c
 assert_eq "$install_image_idx0" "0" "install.sh has no containers[0].image reads (sidecar safety)"
 assert_eq "$patching_image_idx0" "0" "patching.sh has no containers[0].image reads (sidecar safety)"
 
+# ---------------------------------------------------------------------------
+# Test 36: GPU detection Stage 1 code matches between scripts
+# Both scripts must initialize the same GPU variables and use the same
+# kubectl + awk pipeline for node counting and DCGM pod detection.
+# ---------------------------------------------------------------------------
+install_gpu_vars=$(grep -E '^(GPU_NODE_COUNT|TOTAL_GPU_COUNT|GPU_MONITORING_STATUS|DCGM_PODS_OURS|DCGM_PODS_OTHER|DCGM_PODS_TOTAL)=' "$ROOT/install.sh" | sed 's/^[[:space:]]*//' | sort)
+patching_gpu_vars=$(grep -E '^(GPU_NODE_COUNT|TOTAL_GPU_COUNT|GPU_MONITORING_STATUS|DCGM_PODS_OURS|DCGM_PODS_OTHER|DCGM_PODS_TOTAL)=' "$ROOT/src/patching.sh" | sed 's/^[[:space:]]*//' | sort)
+assert_ne "$install_gpu_vars" "" "install.sh initializes GPU detection variables"
+assert_eq "$install_gpu_vars" "$patching_gpu_vars" "GPU detection variable initializations match"
+
+# ---------------------------------------------------------------------------
+# Test 37: Both scripts detect DCGM pods in onelens-agent namespace
+# ---------------------------------------------------------------------------
+install_dcgm_ours=$(grep -c 'kubectl get pods -n onelens-agent -l app=nvidia-dcgm-exporter' "$ROOT/install.sh" || true)
+patching_dcgm_ours=$(grep -c 'kubectl get pods -n onelens-agent -l app=nvidia-dcgm-exporter' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_dcgm_ours" "0" "install.sh checks for DCGM pods in onelens-agent namespace"
+assert_gt "$patching_dcgm_ours" "0" "patching.sh checks for DCGM pods in onelens-agent namespace"
+
+# ---------------------------------------------------------------------------
+# Test 38: Both scripts detect DCGM pods cluster-wide
+# ---------------------------------------------------------------------------
+install_dcgm_all=$(grep -c 'kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter' "$ROOT/install.sh" || true)
+patching_dcgm_all=$(grep -c 'kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_dcgm_all" "0" "install.sh checks for DCGM pods cluster-wide"
+assert_gt "$patching_dcgm_all" "0" "patching.sh checks for DCGM pods cluster-wide"
+
+# ---------------------------------------------------------------------------
+# Test 39: Both scripts emit GPU_MONITORING_STATUS log line
+# ---------------------------------------------------------------------------
+install_status_log=$(grep -c 'echo "GPU_MONITORING_STATUS=' "$ROOT/install.sh" || true)
+patching_status_log=$(grep -c 'echo "GPU_MONITORING_STATUS=' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_status_log" "0" "install.sh emits GPU_MONITORING_STATUS log line"
+assert_gt "$patching_status_log" "0" "patching.sh emits GPU_MONITORING_STATUS log line"
+
+# ---------------------------------------------------------------------------
+# Test 40: Only patching.sh has Prometheus PROF metric check (Stage 2)
+# install.sh has no Prometheus at install time — intentional difference.
+# ---------------------------------------------------------------------------
+patching_prof_check=$(grep -c 'DCGM_FI_PROF_GR_ENGINE_ACTIVE' "$ROOT/src/patching.sh" || true)
+install_prof_check=$(grep -c 'DCGM_FI_PROF_GR_ENGINE_ACTIVE' "$ROOT/install.sh" || true)
+assert_gt "$patching_prof_check" "0" "patching.sh has Stage 2 Prometheus PROF metric check"
+assert_eq "$install_prof_check" "0" "install.sh does NOT have Prometheus PROF check (no Prometheus at install time)"
+
+# ---------------------------------------------------------------------------
+# Test 41: Patching.sh Stage 2 guards on PROM_QUERY_URL
+# Prometheus may not be available — Stage 2 must not run if PROM_QUERY_URL is empty.
+# ---------------------------------------------------------------------------
+patching_prom_guard=$(grep 'DCGM_PODS_TOTAL' "$ROOT/src/patching.sh" | grep -c 'PROM_QUERY_URL' || true)
+assert_gt "$patching_prom_guard" "0" "patching.sh Stage 2 guards on PROM_QUERY_URL availability"
+
 test_summary
 exit $?


### PR DESCRIPTION
## Summary
- Enhanced GPU detection in `src/patching.sh` and `install.sh` with two-stage approach
- Stage 1 (kubectl): detects GPU nodes, DCGM pods (ours vs customer-managed), logs guidance
- Stage 2 (Prometheus, patching.sh only): queries `DCGM_FI_PROF_GR_ENGINE_ACTIVE` for DCGM config validation
- Reports one of four states: `not_applicable`, `cost_only`, `dcgm_misconfigured`, `fully_configured`
- Emits grep-able `GPU_MONITORING_STATUS=<value>` in patching_logs for fleet-wide GPU readiness queries
- 11 new parity tests added (800 total, 0 failures)

## Test plan
- [x] `bash tests/run-all.sh` — 800 tests passing
- [x] Validated kubectl commands on test cluster with `onelensupdater-sa` RBAC impersonation
- [x] Validated Prometheus query returns clean results
- [x] Verified non-GPU cluster: silent (no GPU log output)
- [ ] Post-release: validate on GPU cluster with DCGM (requires nodegroup scale-up)
- [ ] Post-release: validate `dcgm_misconfigured` path (DCGM without `-f` flag)