### PR TITLE
feat(gpu): Phase 2 — auto-deploy DCGM exporter on GPU clusters

### DIFF
--- a/charts/onelens-agent/values.yaml
+++ b/charts/onelens-agent/values.yaml
@@ -87,6 +87,10 @@ onelens-agent:
     API_BASE_URL: "https://dev-api.onelens.cloud" # DON'T ADD TRAILING SLASH
     CLUSTER_TOKEN: "your-raw-token" # Don't encode
     REGISTRATION_ID: "your-raw-id" # Don't encode
+  gpu:
+    enabled: "false"
+    dcgmExporter:
+      image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04
 prometheus:
   enabled: true
   server:

--- a/globalvalues.yaml
+++ b/globalvalues.yaml
@@ -63,6 +63,10 @@ onelens-agent:
     API_BASE_URL: "https://dev-api.onelens.cloud" # DON'T ADD TRAILING SLASH
     CLUSTER_TOKEN: "your-raw-token" # Don't encode
     REGISTRATION_ID: "your-raw-id" # Don't encode
+  gpu:
+    enabled: "false"
+    dcgmExporter:
+      image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04
 prometheus:
   enabled: true
   rbac:

--- a/install.sh
+++ b/install.sh
@@ -389,7 +389,10 @@ if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     echo "GPU nodes: $GPU_NODE_COUNT nodes, $TOTAL_GPU_COUNT GPUs total"
     GPU_MONITORING_STATUS="cost_only"
     DCGM_PODS_OURS=$(kubectl get pods -n onelens-agent -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | wc -l | tr -d '[:space:]')
-    DCGM_PODS_OTHER=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    # Broad detection: check both standalone DCGM label and GPU Operator label
+    dcgm_by_app=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    dcgm_by_operator=$(kubectl get pods --all-namespaces -l app.kubernetes.io/component=dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    DCGM_PODS_OTHER=$(( dcgm_by_app > dcgm_by_operator ? dcgm_by_app : dcgm_by_operator ))
     DCGM_PODS_TOTAL=$((DCGM_PODS_OURS + DCGM_PODS_OTHER))
     if [ "$DCGM_PODS_TOTAL" -eq 0 ] 2>/dev/null; then
         echo "WARNING: GPU nodes found but NVIDIA DCGM exporter not detected — GPU utilization metrics unavailable"
@@ -619,8 +622,7 @@ CMD="helm upgrade --install onelens-agent -n onelens-agent $CREATE_NS_FLAG $CHAR
     --set-string prometheus.server.retention=\"$PROMETHEUS_RETENTION\" \
     --set-string prometheus.server.retentionSize=\"$PROMETHEUS_RETENTION_SIZE\" \
     --set-string prometheus.server.persistentVolume.size=\"$PROMETHEUS_VOLUME_SIZE\" \
-    --set onelens-agent.storageClass.provisioner=\"$STORAGE_CLASS_PROVISIONER\" \
-    --set-string onelens-agent.gpu.enabled=\"$GPU_ENABLED\""
+    --set onelens-agent.storageClass.provisioner=\"$STORAGE_CLASS_PROVISIONER\""
 
 # Air-gapped: override all image sources to private registry.
 # Charts that use "{repository}:{tag}" get repository=$REGISTRY_URL/<name>.
@@ -638,7 +640,6 @@ if [ -n "$REGISTRY_URL" ]; then
     CMD+=" --set prometheus.prometheus-pushgateway.image.repository=$REGISTRY_URL/pushgateway"
     CMD+=" --set prometheus.kube-state-metrics.kubeRBACProxy.image.registry=$REGISTRY_URL"
     CMD+=" --set prometheus.kube-state-metrics.kubeRBACProxy.image.repository=kube-rbac-proxy"
-    CMD+=" --set onelens-agent.gpu.dcgmExporter.image=$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
     CMD+=" --set onelens-agent.env.REGISTRY_URL=$REGISTRY_URL"
 fi
 
@@ -809,6 +810,93 @@ fi
 
 echo ""
 echo "Helm install succeeded. Resources submitted to cluster."
+
+# --- GPU Phase 2: deploy DCGM exporter via kubectl (decoupled from helm) ---
+# Deployed separately so DCGM failures (PSA blocking SYS_ADMIN, image pull, etc.)
+# cannot block the main helm install.
+if [ "$GPU_ENABLED" = "true" ]; then
+    DCGM_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
+    if [ -n "$REGISTRY_URL" ]; then
+        DCGM_IMAGE="$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
+    fi
+    echo "Deploying DCGM exporter DaemonSet (image: $DCGM_IMAGE)"
+    if kubectl apply -n onelens-agent -f - <<DCGM_EOF 2>&1
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-dcgm-exporter
+  namespace: onelens-agent
+  labels:
+    app: nvidia-dcgm-exporter
+    managed-by: onelens
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-dcgm-exporter
+  template:
+    metadata:
+      labels:
+        app: nvidia-dcgm-exporter
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: dcgm-exporter
+          image: $DCGM_IMAGE
+          args: ["-f", "/etc/dcgm-exporter/dcp-metrics-included.csv"]
+          ports:
+            - name: metrics
+              containerPort: 9400
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN"]
+          env:
+            - name: DCGM_EXPORTER_KUBERNETES
+              value: "true"
+            - name: DCGM_EXPORTER_LISTEN
+              value: ":9400"
+          volumeMounts:
+            - name: pod-resources
+              mountPath: /var/lib/kubelet/pod-resources
+              readOnly: true
+      volumes:
+        - name: pod-resources
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nvidia-dcgm-exporter
+  namespace: onelens-agent
+  labels:
+    app: nvidia-dcgm-exporter
+    managed-by: onelens
+spec:
+  selector:
+    app: nvidia-dcgm-exporter
+  ports:
+    - name: gpu-metrics
+      port: 9400
+      targetPort: 9400
+DCGM_EOF
+    then
+        echo "DCGM exporter deployed successfully"
+    else
+        echo "WARNING: DCGM exporter deployment failed — GPU utilization monitoring unavailable"
+        echo "  This does not affect other OneLens components."
+        echo "  Common causes: Pod Security Admission blocking SYS_ADMIN or hostPath mounts."
+    fi
+fi
 
 # Wait for Prometheus PVC to be bound — proves the PV was provisioned by the CSI driver.
 # This is the only hard dependency: without a bound PV, Prometheus can't start and

--- a/install.sh
+++ b/install.sh
@@ -403,6 +403,19 @@ if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     echo "GPU_MONITORING_STATUS=$GPU_MONITORING_STATUS"
 fi
 
+# --- GPU Phase 2: resolve gpu.enabled for helm install ---
+# No customer-override check needed (fresh install, no existing release).
+GPU_ENABLED="false"
+if [ "$GPU_NODE_COUNT" -gt 0 ]; then
+    if [ "$DCGM_PODS_OTHER" -gt 0 ] 2>/dev/null; then
+        GPU_ENABLED="false"
+        echo "GPU helm value: gpu.enabled=false (existing customer DCGM detected)"
+    else
+        GPU_ENABLED="true"
+        echo "GPU helm value: gpu.enabled=true (deploying OneLens DCGM exporter)"
+    fi
+fi
+
 # --- Air-gapped self-detection ---
 # If the deployer pod's image is NOT from public.ecr.aws, this is an air-gapped cluster.
 # Extract the private registry URL from the image path for chart pulls and image overrides.
@@ -606,7 +619,8 @@ CMD="helm upgrade --install onelens-agent -n onelens-agent $CREATE_NS_FLAG $CHAR
     --set-string prometheus.server.retention=\"$PROMETHEUS_RETENTION\" \
     --set-string prometheus.server.retentionSize=\"$PROMETHEUS_RETENTION_SIZE\" \
     --set-string prometheus.server.persistentVolume.size=\"$PROMETHEUS_VOLUME_SIZE\" \
-    --set onelens-agent.storageClass.provisioner=\"$STORAGE_CLASS_PROVISIONER\""
+    --set onelens-agent.storageClass.provisioner=\"$STORAGE_CLASS_PROVISIONER\" \
+    --set-string onelens-agent.gpu.enabled=\"$GPU_ENABLED\""
 
 # Air-gapped: override all image sources to private registry.
 # Charts that use "{repository}:{tag}" get repository=$REGISTRY_URL/<name>.
@@ -624,6 +638,7 @@ if [ -n "$REGISTRY_URL" ]; then
     CMD+=" --set prometheus.prometheus-pushgateway.image.repository=$REGISTRY_URL/pushgateway"
     CMD+=" --set prometheus.kube-state-metrics.kubeRBACProxy.image.registry=$REGISTRY_URL"
     CMD+=" --set prometheus.kube-state-metrics.kubeRBACProxy.image.repository=kube-rbac-proxy"
+    CMD+=" --set onelens-agent.gpu.dcgmExporter.image=$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
     CMD+=" --set onelens-agent.env.REGISTRY_URL=$REGISTRY_URL"
 fi
 

--- a/patching.sh
+++ b/patching.sh
@@ -1258,6 +1258,7 @@ if [[ -n "$CURRENT_VALUES" ]] && command -v jq &>/dev/null; then
   REGISTRATION_ID=$(_get '.["onelens-agent"].secrets.REGISTRATION_ID')
   DEFAULT_CLUSTER_ID=$(_get '.["prometheus-opencost-exporter"].opencost.exporter.defaultClusterId')
   REGISTRY_URL=$(_get '.["onelens-agent"].env.REGISTRY_URL')
+  GPU_ENABLED_OVERRIDE=$(_get '.["onelens-agent"].gpu.enabled')
   # Note: Can't use _get for booleans — jq's `false // empty` returns empty since false is falsy
   PVC_ENABLED=$(echo "$CURRENT_VALUES" | jq -r '.prometheus.server.persistentVolume.enabled // "true"')
 
@@ -1324,6 +1325,7 @@ else
   REGISTRATION_ID="${REGISTRATION_ID:-}"
   DEFAULT_CLUSTER_ID=""
   REGISTRY_URL=""
+  GPU_ENABLED_OVERRIDE=""
   PVC_ENABLED="true"
   SC_PROVISIONER=""
   CUSTOMER_VALUES_FILE=""
@@ -1791,6 +1793,26 @@ if [ "$GPU_NODE_COUNT" -gt 0 ] && [ "$DCGM_PODS_TOTAL" -gt 0 ] 2>/dev/null && [ 
 fi
 if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     echo "GPU_MONITORING_STATUS=$GPU_MONITORING_STATUS"
+fi
+
+# --- GPU Phase 2: resolve gpu.enabled for helm upgrade ---
+# Decides whether to deploy the DCGM exporter DaemonSet via the chart.
+# - Customer explicitly set "true" or "false" → respect it
+# - GPU nodes + customer-managed DCGM (outside onelens-agent ns) → false (don't conflict)
+# - GPU nodes + no customer DCGM → true (deploy ours)
+# - No GPU nodes → false
+GPU_ENABLED="false"
+if [ -n "${GPU_ENABLED_OVERRIDE:-}" ] && [ "$GPU_ENABLED_OVERRIDE" != "auto" ]; then
+    GPU_ENABLED="$GPU_ENABLED_OVERRIDE"
+    echo "GPU helm value: gpu.enabled=$GPU_ENABLED (customer override)"
+elif [ "$GPU_NODE_COUNT" -gt 0 ]; then
+    if [ "$DCGM_PODS_OTHER" -gt 0 ] 2>/dev/null; then
+        GPU_ENABLED="false"
+        echo "GPU helm value: gpu.enabled=false (customer-managed DCGM detected)"
+    else
+        GPU_ENABLED="true"
+        echo "GPU helm value: gpu.enabled=true (deploying OneLens DCGM exporter)"
+    fi
 fi
 
 # --- Agent OOM pre-helm detection ---
@@ -2440,6 +2462,9 @@ HELM_CMD="$HELM_CMD \
   --set prometheus.configmapReload.prometheus.resources.limits.cpu=\"$PROMETHEUS_CONFIGMAP_RELOAD_CPU_LIMIT\" \
   --set prometheus.configmapReload.prometheus.resources.limits.memory=\"$PROMETHEUS_CONFIGMAP_RELOAD_MEMORY_LIMIT\""
 
+# GPU monitoring (Phase 2: conditional DCGM exporter DaemonSet)
+HELM_CMD="$HELM_CMD --set-string onelens-agent.gpu.enabled=\"$GPU_ENABLED\""
+
 # Air-gapped: override all image sources to private registry and persist REGISTRY_URL.
 # Charts that use "{repository}:{tag}" get repository=$REGISTRY_URL/<name>.
 # Charts that use "{registry}/{repository}:{tag}" get registry=$REGISTRY_URL + repository=<name>
@@ -2457,6 +2482,7 @@ if [ -n "$REGISTRY_URL" ]; then
       --set prometheus.prometheus-pushgateway.image.repository=$REGISTRY_URL/pushgateway \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.registry=$REGISTRY_URL \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.repository=kube-rbac-proxy \
+      --set onelens-agent.gpu.dcgmExporter.image=$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04 \
       --set onelens-agent.env.REGISTRY_URL=$REGISTRY_URL"
 fi
 

--- a/patching.sh
+++ b/patching.sh
@@ -1193,7 +1193,10 @@ if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     echo "GPU nodes: $GPU_NODE_COUNT nodes, $TOTAL_GPU_COUNT GPUs total"
     GPU_MONITORING_STATUS="cost_only"
     DCGM_PODS_OURS=$(kubectl get pods -n onelens-agent -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | wc -l | tr -d '[:space:]')
-    DCGM_PODS_OTHER=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    # Broad detection: check both standalone DCGM label and GPU Operator label
+    dcgm_by_app=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    dcgm_by_operator=$(kubectl get pods --all-namespaces -l app.kubernetes.io/component=dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    DCGM_PODS_OTHER=$(( dcgm_by_app > dcgm_by_operator ? dcgm_by_app : dcgm_by_operator ))
     DCGM_PODS_TOTAL=$((DCGM_PODS_OURS + DCGM_PODS_OTHER))
     if [ "$DCGM_PODS_TOTAL" -eq 0 ] 2>/dev/null; then
         echo "WARNING: GPU nodes found but NVIDIA DCGM exporter not detected — GPU utilization metrics unavailable"
@@ -2462,9 +2465,6 @@ HELM_CMD="$HELM_CMD \
   --set prometheus.configmapReload.prometheus.resources.limits.cpu=\"$PROMETHEUS_CONFIGMAP_RELOAD_CPU_LIMIT\" \
   --set prometheus.configmapReload.prometheus.resources.limits.memory=\"$PROMETHEUS_CONFIGMAP_RELOAD_MEMORY_LIMIT\""
 
-# GPU monitoring (Phase 2: conditional DCGM exporter DaemonSet)
-HELM_CMD="$HELM_CMD --set-string onelens-agent.gpu.enabled=\"$GPU_ENABLED\""
-
 # Air-gapped: override all image sources to private registry and persist REGISTRY_URL.
 # Charts that use "{repository}:{tag}" get repository=$REGISTRY_URL/<name>.
 # Charts that use "{registry}/{repository}:{tag}" get registry=$REGISTRY_URL + repository=<name>
@@ -2482,7 +2482,6 @@ if [ -n "$REGISTRY_URL" ]; then
       --set prometheus.prometheus-pushgateway.image.repository=$REGISTRY_URL/pushgateway \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.registry=$REGISTRY_URL \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.repository=kube-rbac-proxy \
-      --set onelens-agent.gpu.dcgmExporter.image=$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04 \
       --set onelens-agent.env.REGISTRY_URL=$REGISTRY_URL"
 fi
 
@@ -3093,6 +3092,101 @@ echo "Running helm upgrade (latest chart, fresh values + customer overrides)..."
 _report_milestone  # M7: helm-upgrade-start — all sizing done, about to apply
 eval "$HELM_CMD"
 UPGRADE_EXIT=$?
+
+# --- GPU Phase 2: deploy/cleanup DCGM exporter via kubectl (decoupled from helm) ---
+# Deployed separately so DCGM failures (PSA blocking SYS_ADMIN, image pull, etc.)
+# cannot block the main helm upgrade via --wait timeout.
+if [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_ENABLED" = "true" ]; then
+    DCGM_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
+    if [ -n "$REGISTRY_URL" ]; then
+        DCGM_IMAGE="$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
+    fi
+    echo "Deploying DCGM exporter DaemonSet (image: $DCGM_IMAGE)"
+    if kubectl apply -n onelens-agent -f - <<DCGM_EOF 2>&1
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-dcgm-exporter
+  namespace: onelens-agent
+  labels:
+    app: nvidia-dcgm-exporter
+    managed-by: onelens
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-dcgm-exporter
+  template:
+    metadata:
+      labels:
+        app: nvidia-dcgm-exporter
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: dcgm-exporter
+          image: $DCGM_IMAGE
+          args: ["-f", "/etc/dcgm-exporter/dcp-metrics-included.csv"]
+          ports:
+            - name: metrics
+              containerPort: 9400
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN"]
+          env:
+            - name: DCGM_EXPORTER_KUBERNETES
+              value: "true"
+            - name: DCGM_EXPORTER_LISTEN
+              value: ":9400"
+          volumeMounts:
+            - name: pod-resources
+              mountPath: /var/lib/kubelet/pod-resources
+              readOnly: true
+      volumes:
+        - name: pod-resources
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nvidia-dcgm-exporter
+  namespace: onelens-agent
+  labels:
+    app: nvidia-dcgm-exporter
+    managed-by: onelens
+spec:
+  selector:
+    app: nvidia-dcgm-exporter
+  ports:
+    - name: gpu-metrics
+      port: 9400
+      targetPort: 9400
+DCGM_EOF
+    then
+        echo "DCGM exporter deployed successfully"
+    else
+        echo "WARNING: DCGM exporter deployment failed — GPU utilization monitoring unavailable"
+        echo "  This does not affect other OneLens components."
+        echo "  Common causes: Pod Security Admission blocking SYS_ADMIN or hostPath mounts."
+    fi
+elif [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_ENABLED" = "false" ]; then
+    # Clean up OneLens-managed DCGM if it was previously deployed but is no longer needed
+    # (e.g., customer installed their own DCGM, or GPU nodes were removed)
+    if kubectl get ds nvidia-dcgm-exporter -n onelens-agent -l managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
+        echo "Cleaning up OneLens DCGM exporter (no longer needed)"
+        kubectl delete ds nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
+        kubectl delete svc nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
+    fi
+fi
 
 # Retry loop: if any pod OOMs after upgrade, bump that component and retry immediately
 while true; do

--- a/scripts/airgapped/airgapped_migrate_images.sh
+++ b/scripts/airgapped/airgapped_migrate_images.sh
@@ -218,6 +218,16 @@ else
     echo "  WARNING: Skipping pushgateway — could not determine tag."
 fi
 
+# dcgm-exporter (GPU monitoring — only deployed on GPU clusters)
+_repo="nvcr.io/nvidia/k8s/dcgm-exporter"
+_tag=$(grep 'dcgmExporter' "$_V" -A1 | grep 'image:' | head -1 | awk -F: '{print $NF}' | tr -d ' "' || true)
+if [ -z "$_tag" ]; then
+    _tag="3.3.9-3.6.1-ubuntu22.04"
+fi
+IMAGES="${IMAGES}
+${_repo}:${_tag} dcgm-exporter:${_tag}"
+echo "  dcgm-exporter: ${_repo}:${_tag}"
+
 # --- Mirror images ---
 echo ""
 echo "=== Mirroring images ==="

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -369,7 +369,10 @@ if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     echo "GPU nodes: $GPU_NODE_COUNT nodes, $TOTAL_GPU_COUNT GPUs total"
     GPU_MONITORING_STATUS="cost_only"
     DCGM_PODS_OURS=$(kubectl get pods -n onelens-agent -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | wc -l | tr -d '[:space:]')
-    DCGM_PODS_OTHER=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    # Broad detection: check both standalone DCGM label and GPU Operator label
+    dcgm_by_app=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    dcgm_by_operator=$(kubectl get pods --all-namespaces -l app.kubernetes.io/component=dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+    DCGM_PODS_OTHER=$(( dcgm_by_app > dcgm_by_operator ? dcgm_by_app : dcgm_by_operator ))
     DCGM_PODS_TOTAL=$((DCGM_PODS_OURS + DCGM_PODS_OTHER))
     if [ "$DCGM_PODS_TOTAL" -eq 0 ] 2>/dev/null; then
         echo "WARNING: GPU nodes found but NVIDIA DCGM exporter not detected — GPU utilization metrics unavailable"
@@ -1638,9 +1641,6 @@ HELM_CMD="$HELM_CMD \
   --set prometheus.configmapReload.prometheus.resources.limits.cpu=\"$PROMETHEUS_CONFIGMAP_RELOAD_CPU_LIMIT\" \
   --set prometheus.configmapReload.prometheus.resources.limits.memory=\"$PROMETHEUS_CONFIGMAP_RELOAD_MEMORY_LIMIT\""
 
-# GPU monitoring (Phase 2: conditional DCGM exporter DaemonSet)
-HELM_CMD="$HELM_CMD --set-string onelens-agent.gpu.enabled=\"$GPU_ENABLED\""
-
 # Air-gapped: override all image sources to private registry and persist REGISTRY_URL.
 # Charts that use "{repository}:{tag}" get repository=$REGISTRY_URL/<name>.
 # Charts that use "{registry}/{repository}:{tag}" get registry=$REGISTRY_URL + repository=<name>
@@ -1658,7 +1658,6 @@ if [ -n "$REGISTRY_URL" ]; then
       --set prometheus.prometheus-pushgateway.image.repository=$REGISTRY_URL/pushgateway \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.registry=$REGISTRY_URL \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.repository=kube-rbac-proxy \
-      --set onelens-agent.gpu.dcgmExporter.image=$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04 \
       --set onelens-agent.env.REGISTRY_URL=$REGISTRY_URL"
 fi
 
@@ -2269,6 +2268,101 @@ echo "Running helm upgrade (latest chart, fresh values + customer overrides)..."
 _report_milestone  # M7: helm-upgrade-start — all sizing done, about to apply
 eval "$HELM_CMD"
 UPGRADE_EXIT=$?
+
+# --- GPU Phase 2: deploy/cleanup DCGM exporter via kubectl (decoupled from helm) ---
+# Deployed separately so DCGM failures (PSA blocking SYS_ADMIN, image pull, etc.)
+# cannot block the main helm upgrade via --wait timeout.
+if [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_ENABLED" = "true" ]; then
+    DCGM_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
+    if [ -n "$REGISTRY_URL" ]; then
+        DCGM_IMAGE="$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
+    fi
+    echo "Deploying DCGM exporter DaemonSet (image: $DCGM_IMAGE)"
+    if kubectl apply -n onelens-agent -f - <<DCGM_EOF 2>&1
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-dcgm-exporter
+  namespace: onelens-agent
+  labels:
+    app: nvidia-dcgm-exporter
+    managed-by: onelens
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-dcgm-exporter
+  template:
+    metadata:
+      labels:
+        app: nvidia-dcgm-exporter
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: dcgm-exporter
+          image: $DCGM_IMAGE
+          args: ["-f", "/etc/dcgm-exporter/dcp-metrics-included.csv"]
+          ports:
+            - name: metrics
+              containerPort: 9400
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN"]
+          env:
+            - name: DCGM_EXPORTER_KUBERNETES
+              value: "true"
+            - name: DCGM_EXPORTER_LISTEN
+              value: ":9400"
+          volumeMounts:
+            - name: pod-resources
+              mountPath: /var/lib/kubelet/pod-resources
+              readOnly: true
+      volumes:
+        - name: pod-resources
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nvidia-dcgm-exporter
+  namespace: onelens-agent
+  labels:
+    app: nvidia-dcgm-exporter
+    managed-by: onelens
+spec:
+  selector:
+    app: nvidia-dcgm-exporter
+  ports:
+    - name: gpu-metrics
+      port: 9400
+      targetPort: 9400
+DCGM_EOF
+    then
+        echo "DCGM exporter deployed successfully"
+    else
+        echo "WARNING: DCGM exporter deployment failed — GPU utilization monitoring unavailable"
+        echo "  This does not affect other OneLens components."
+        echo "  Common causes: Pod Security Admission blocking SYS_ADMIN or hostPath mounts."
+    fi
+elif [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_ENABLED" = "false" ]; then
+    # Clean up OneLens-managed DCGM if it was previously deployed but is no longer needed
+    # (e.g., customer installed their own DCGM, or GPU nodes were removed)
+    if kubectl get ds nvidia-dcgm-exporter -n onelens-agent -l managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
+        echo "Cleaning up OneLens DCGM exporter (no longer needed)"
+        kubectl delete ds nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
+        kubectl delete svc nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
+    fi
+fi
 
 # Retry loop: if any pod OOMs after upgrade, bump that component and retry immediately
 while true; do

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -434,6 +434,7 @@ if [[ -n "$CURRENT_VALUES" ]] && command -v jq &>/dev/null; then
   REGISTRATION_ID=$(_get '.["onelens-agent"].secrets.REGISTRATION_ID')
   DEFAULT_CLUSTER_ID=$(_get '.["prometheus-opencost-exporter"].opencost.exporter.defaultClusterId')
   REGISTRY_URL=$(_get '.["onelens-agent"].env.REGISTRY_URL')
+  GPU_ENABLED_OVERRIDE=$(_get '.["onelens-agent"].gpu.enabled')
   # Note: Can't use _get for booleans — jq's `false // empty` returns empty since false is falsy
   PVC_ENABLED=$(echo "$CURRENT_VALUES" | jq -r '.prometheus.server.persistentVolume.enabled // "true"')
 
@@ -500,6 +501,7 @@ else
   REGISTRATION_ID="${REGISTRATION_ID:-}"
   DEFAULT_CLUSTER_ID=""
   REGISTRY_URL=""
+  GPU_ENABLED_OVERRIDE=""
   PVC_ENABLED="true"
   SC_PROVISIONER=""
   CUSTOMER_VALUES_FILE=""
@@ -967,6 +969,26 @@ if [ "$GPU_NODE_COUNT" -gt 0 ] && [ "$DCGM_PODS_TOTAL" -gt 0 ] 2>/dev/null && [ 
 fi
 if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     echo "GPU_MONITORING_STATUS=$GPU_MONITORING_STATUS"
+fi
+
+# --- GPU Phase 2: resolve gpu.enabled for helm upgrade ---
+# Decides whether to deploy the DCGM exporter DaemonSet via the chart.
+# - Customer explicitly set "true" or "false" → respect it
+# - GPU nodes + customer-managed DCGM (outside onelens-agent ns) → false (don't conflict)
+# - GPU nodes + no customer DCGM → true (deploy ours)
+# - No GPU nodes → false
+GPU_ENABLED="false"
+if [ -n "${GPU_ENABLED_OVERRIDE:-}" ] && [ "$GPU_ENABLED_OVERRIDE" != "auto" ]; then
+    GPU_ENABLED="$GPU_ENABLED_OVERRIDE"
+    echo "GPU helm value: gpu.enabled=$GPU_ENABLED (customer override)"
+elif [ "$GPU_NODE_COUNT" -gt 0 ]; then
+    if [ "$DCGM_PODS_OTHER" -gt 0 ] 2>/dev/null; then
+        GPU_ENABLED="false"
+        echo "GPU helm value: gpu.enabled=false (customer-managed DCGM detected)"
+    else
+        GPU_ENABLED="true"
+        echo "GPU helm value: gpu.enabled=true (deploying OneLens DCGM exporter)"
+    fi
 fi
 
 # --- Agent OOM pre-helm detection ---
@@ -1616,6 +1638,9 @@ HELM_CMD="$HELM_CMD \
   --set prometheus.configmapReload.prometheus.resources.limits.cpu=\"$PROMETHEUS_CONFIGMAP_RELOAD_CPU_LIMIT\" \
   --set prometheus.configmapReload.prometheus.resources.limits.memory=\"$PROMETHEUS_CONFIGMAP_RELOAD_MEMORY_LIMIT\""
 
+# GPU monitoring (Phase 2: conditional DCGM exporter DaemonSet)
+HELM_CMD="$HELM_CMD --set-string onelens-agent.gpu.enabled=\"$GPU_ENABLED\""
+
 # Air-gapped: override all image sources to private registry and persist REGISTRY_URL.
 # Charts that use "{repository}:{tag}" get repository=$REGISTRY_URL/<name>.
 # Charts that use "{registry}/{repository}:{tag}" get registry=$REGISTRY_URL + repository=<name>
@@ -1633,6 +1658,7 @@ if [ -n "$REGISTRY_URL" ]; then
       --set prometheus.prometheus-pushgateway.image.repository=$REGISTRY_URL/pushgateway \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.registry=$REGISTRY_URL \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.repository=kube-rbac-proxy \
+      --set onelens-agent.gpu.dcgmExporter.image=$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04 \
       --set onelens-agent.env.REGISTRY_URL=$REGISTRY_URL"
 fi
 

--- a/tests/test-airgapped.sh
+++ b/tests/test-airgapped.sh
@@ -54,16 +54,17 @@ assert_gt "$install_persist" "0" "install.sh persists REGISTRY_URL in helm value
 assert_gt "$patching_persist" "0" "patching.sh re-persists REGISTRY_URL in helm values"
 
 # ---------------------------------------------------------------------------
-# Test 8: Exactly 11 image override flags per script
-# 7 image overrides (some need both registry + repository) + 1 REGISTRY_URL persistence = 11
+# Test 8: Exactly 12 image override flags per script
+# 7 image overrides (some need both registry + repository) + 1 DCGM exporter image
+# + 1 REGISTRY_URL persistence = 12
 # Components using {registry}/{repository}:{tag} (KSM, OpenCost, kube-rbac-proxy)
 # need both registry and repository overridden to flatten the ECR path.
 # Count all --set lines inside the air-gapped if-block (between REGISTRY_URL check and fi).
 # ---------------------------------------------------------------------------
 install_override_count=$(sed -n '/Air-gapped: override all image/,/^fi$/p' "$ROOT/install.sh" | grep -c '\-\-set ' || true)
 patching_override_count=$(sed -n '/Air-gapped: override all image/,/^fi$/p' "$ROOT/src/patching.sh" | grep -c '\-\-set ' || true)
-assert_eq "$install_override_count" "11" "install.sh has exactly 11 air-gapped --set flags"
-assert_eq "$patching_override_count" "11" "patching.sh has exactly 11 air-gapped --set flags"
+assert_eq "$install_override_count" "12" "install.sh has exactly 12 air-gapped --set flags"
+assert_eq "$patching_override_count" "12" "patching.sh has exactly 12 air-gapped --set flags"
 
 # ---------------------------------------------------------------------------
 # Test 9: No hardcoded REGISTRY_URL in helm command (parameterized only)

--- a/tests/test-airgapped.sh
+++ b/tests/test-airgapped.sh
@@ -54,17 +54,17 @@ assert_gt "$install_persist" "0" "install.sh persists REGISTRY_URL in helm value
 assert_gt "$patching_persist" "0" "patching.sh re-persists REGISTRY_URL in helm values"
 
 # ---------------------------------------------------------------------------
-# Test 8: Exactly 12 image override flags per script
-# 7 image overrides (some need both registry + repository) + 1 DCGM exporter image
-# + 1 REGISTRY_URL persistence = 12
+# Test 8: Exactly 11 image override flags per script
+# 7 image overrides (some need both registry + repository) + 1 REGISTRY_URL persistence = 11
+# DCGM image is NOT in the helm air-gapped section — it's handled separately via kubectl apply.
 # Components using {registry}/{repository}:{tag} (KSM, OpenCost, kube-rbac-proxy)
 # need both registry and repository overridden to flatten the ECR path.
 # Count all --set lines inside the air-gapped if-block (between REGISTRY_URL check and fi).
 # ---------------------------------------------------------------------------
 install_override_count=$(sed -n '/Air-gapped: override all image/,/^fi$/p' "$ROOT/install.sh" | grep -c '\-\-set ' || true)
 patching_override_count=$(sed -n '/Air-gapped: override all image/,/^fi$/p' "$ROOT/src/patching.sh" | grep -c '\-\-set ' || true)
-assert_eq "$install_override_count" "12" "install.sh has exactly 12 air-gapped --set flags"
-assert_eq "$patching_override_count" "12" "patching.sh has exactly 12 air-gapped --set flags"
+assert_eq "$install_override_count" "11" "install.sh has exactly 11 air-gapped --set flags"
+assert_eq "$patching_override_count" "11" "patching.sh has exactly 11 air-gapped --set flags"
 
 # ---------------------------------------------------------------------------
 # Test 9: No hardcoded REGISTRY_URL in helm command (parameterized only)

--- a/tests/test-build.sh
+++ b/tests/test-build.sh
@@ -379,5 +379,53 @@ assert_ge "$orphan_detection" "1" "src/patching.sh detects orphaned Jobs (no pod
 old_stuck_pod_delete=$(grep -c 'kubectl delete pod.*AGENT_STUCK_POD' "$SRC_FILE" || true)
 assert_eq "$old_stuck_pod_delete" "0" "src/patching.sh old pod-deletion stuck cleanup removed"
 
+# ---------------------------------------------------------------------------
+# GPU Phase 2: chart values and template tests
+# ---------------------------------------------------------------------------
+
+# globalvalues.yaml has gpu section under onelens-agent
+gv_gpu=$(grep -c 'gpu:' "$ROOT/globalvalues.yaml" || true)
+assert_gt "$gv_gpu" "0" "globalvalues.yaml has gpu section"
+
+gv_gpu_enabled=$(grep 'enabled: "false"' "$ROOT/globalvalues.yaml" | grep -v '#' | head -1)
+assert_ne "$gv_gpu_enabled" "" "globalvalues.yaml has gpu.enabled: false (safe default)"
+
+gv_dcgm_image=$(grep -c 'dcgm-exporter' "$ROOT/globalvalues.yaml" || true)
+assert_gt "$gv_dcgm_image" "0" "globalvalues.yaml has DCGM exporter image"
+
+# wrapper chart values.yaml has gpu section
+cv_gpu=$(grep -c 'gpu:' "$ROOT/charts/onelens-agent/values.yaml" || true)
+assert_gt "$cv_gpu" "0" "wrapper chart values.yaml has gpu section"
+
+cv_gpu_enabled=$(grep 'enabled: "false"' "$ROOT/charts/onelens-agent/values.yaml" | grep -v '#' | head -1)
+assert_ne "$cv_gpu_enabled" "" "wrapper chart values.yaml has gpu.enabled: false (safe default)"
+
+# GPU_ENABLED logic is in built patching.sh
+built_gpu_enabled=$(grep -c 'GPU_ENABLED=' "$OUT_FILE" || true)
+assert_gt "$built_gpu_enabled" "0" "built patching.sh has GPU_ENABLED resolution logic"
+
+built_gpu_set=$(grep -c 'set-string onelens-agent.gpu.enabled' "$OUT_FILE" || true)
+assert_gt "$built_gpu_set" "0" "built patching.sh passes --set-string gpu.enabled to helm"
+
+# DCGM template exists in adjacent agent repo (if present)
+AGENT_CHART_DIR="$ROOT/../onelens-agent/helm-chart/onelens-agent-base"
+if [ -d "$AGENT_CHART_DIR" ]; then
+    assert_file_exists "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" "dcgm-exporter.yaml template exists in agent chart"
+    dcgm_node_selector=$(grep -c 'nvidia.com/gpu.present' "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" || true)
+    assert_gt "$dcgm_node_selector" "0" "DCGM template has GPU nodeSelector"
+    dcgm_toleration=$(grep -c 'operator: Exists' "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" || true)
+    assert_gt "$dcgm_toleration" "0" "DCGM template has wildcard toleration"
+    dcgm_service_label=$(grep 'app: nvidia-dcgm-exporter' "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" | head -1)
+    assert_ne "$dcgm_service_label" "" "DCGM template has app label matching Prometheus scrape config"
+    dcgm_port_name=$(grep -c 'gpu-metrics' "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" || true)
+    assert_gt "$dcgm_port_name" "0" "DCGM Service port name matches Prometheus scrape config"
+    dcgm_condition=$(grep -c 'ne .Values.gpu.enabled "false"' "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" || true)
+    assert_gt "$dcgm_condition" "0" "DCGM template is conditional on gpu.enabled"
+    agent_values_gpu=$(grep -c 'gpu:' "$AGENT_CHART_DIR/values.yaml" || true)
+    assert_gt "$agent_values_gpu" "0" "agent-base chart values.yaml has gpu section"
+else
+    echo "  SKIP: onelens-agent repo not adjacent — skipping chart template tests"
+fi
+
 test_summary
 exit $?

--- a/tests/test-build.sh
+++ b/tests/test-build.sh
@@ -383,46 +383,40 @@ assert_eq "$old_stuck_pod_delete" "0" "src/patching.sh old pod-deletion stuck cl
 # GPU Phase 2: chart values and template tests
 # ---------------------------------------------------------------------------
 
-# globalvalues.yaml has gpu section under onelens-agent
+# globalvalues.yaml has gpu section under onelens-agent (for customer opt-out signaling)
 gv_gpu=$(grep -c 'gpu:' "$ROOT/globalvalues.yaml" || true)
 assert_gt "$gv_gpu" "0" "globalvalues.yaml has gpu section"
 
 gv_gpu_enabled=$(grep 'enabled: "false"' "$ROOT/globalvalues.yaml" | grep -v '#' | head -1)
 assert_ne "$gv_gpu_enabled" "" "globalvalues.yaml has gpu.enabled: false (safe default)"
 
-gv_dcgm_image=$(grep -c 'dcgm-exporter' "$ROOT/globalvalues.yaml" || true)
-assert_gt "$gv_dcgm_image" "0" "globalvalues.yaml has DCGM exporter image"
-
-# wrapper chart values.yaml has gpu section
-cv_gpu=$(grep -c 'gpu:' "$ROOT/charts/onelens-agent/values.yaml" || true)
-assert_gt "$cv_gpu" "0" "wrapper chart values.yaml has gpu section"
-
-cv_gpu_enabled=$(grep 'enabled: "false"' "$ROOT/charts/onelens-agent/values.yaml" | grep -v '#' | head -1)
-assert_ne "$cv_gpu_enabled" "" "wrapper chart values.yaml has gpu.enabled: false (safe default)"
-
 # GPU_ENABLED logic is in built patching.sh
 built_gpu_enabled=$(grep -c 'GPU_ENABLED=' "$OUT_FILE" || true)
 assert_gt "$built_gpu_enabled" "0" "built patching.sh has GPU_ENABLED resolution logic"
 
-built_gpu_set=$(grep -c 'set-string onelens-agent.gpu.enabled' "$OUT_FILE" || true)
-assert_gt "$built_gpu_set" "0" "built patching.sh passes --set-string gpu.enabled to helm"
+# DCGM is deployed via kubectl apply (not helm) in built patching.sh
+built_dcgm_kubectl=$(grep -c 'kubectl apply.*DCGM_EOF' "$OUT_FILE" || true)
+assert_gt "$built_dcgm_kubectl" "0" "built patching.sh deploys DCGM via kubectl apply"
 
-# DCGM template exists in adjacent agent repo (if present)
+# DCGM deployment is non-fatal in built patching.sh
+built_dcgm_nonfatal=$(grep -c 'WARNING.*DCGM.*failed' "$OUT_FILE" || true)
+assert_gt "$built_dcgm_nonfatal" "0" "built patching.sh DCGM failure is non-fatal"
+
+# No --set gpu.enabled in built patching.sh (decoupled from helm)
+built_gpu_helm_set=$(grep 'onelens-agent.gpu.enabled' "$OUT_FILE" | grep -c '\-\-set' || true)
+assert_eq "$built_gpu_helm_set" "0" "built patching.sh does NOT pass gpu.enabled to helm"
+
+# DCGM image is from nvcr.io (NVIDIA's registry) in built patching.sh
+built_dcgm_img=$(grep 'nvcr.io/nvidia.*dcgm-exporter' "$OUT_FILE" | head -1)
+assert_ne "$built_dcgm_img" "" "built patching.sh DCGM image is from nvcr.io"
+
+# DCGM template should NOT exist in adjacent agent chart (deployed via kubectl, not helm)
 AGENT_CHART_DIR="$ROOT/../onelens-agent/helm-chart/onelens-agent-base"
 if [ -d "$AGENT_CHART_DIR" ]; then
-    assert_file_exists "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" "dcgm-exporter.yaml template exists in agent chart"
-    dcgm_node_selector=$(grep -c 'nvidia.com/gpu.present' "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" || true)
-    assert_gt "$dcgm_node_selector" "0" "DCGM template has GPU nodeSelector"
-    dcgm_toleration=$(grep -c 'operator: Exists' "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" || true)
-    assert_gt "$dcgm_toleration" "0" "DCGM template has wildcard toleration"
-    dcgm_service_label=$(grep 'app: nvidia-dcgm-exporter' "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" | head -1)
-    assert_ne "$dcgm_service_label" "" "DCGM template has app label matching Prometheus scrape config"
-    dcgm_port_name=$(grep -c 'gpu-metrics' "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" || true)
-    assert_gt "$dcgm_port_name" "0" "DCGM Service port name matches Prometheus scrape config"
-    dcgm_condition=$(grep -c 'ne .Values.gpu.enabled "false"' "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" || true)
-    assert_gt "$dcgm_condition" "0" "DCGM template is conditional on gpu.enabled"
+    dcgm_template_exists=$(ls "$AGENT_CHART_DIR/templates/dcgm-exporter.yaml" 2>/dev/null && echo "1" || echo "0")
+    assert_eq "$dcgm_template_exists" "0" "dcgm-exporter.yaml template does NOT exist in agent chart (decoupled)"
     agent_values_gpu=$(grep -c 'gpu:' "$AGENT_CHART_DIR/values.yaml" || true)
-    assert_gt "$agent_values_gpu" "0" "agent-base chart values.yaml has gpu section"
+    assert_gt "$agent_values_gpu" "0" "agent-base chart values.yaml has gpu section (for opt-out)"
 else
     echo "  SKIP: onelens-agent repo not adjacent — skipping chart template tests"
 fi

--- a/tests/test-parity.sh
+++ b/tests/test-parity.sh
@@ -374,24 +374,24 @@ patching_gpu_enabled_init=$(grep -c '^GPU_ENABLED="false"' "$ROOT/src/patching.s
 assert_gt "$install_gpu_enabled_init" "0" "install.sh initializes GPU_ENABLED"
 assert_gt "$patching_gpu_enabled_init" "0" "patching.sh initializes GPU_ENABLED"
 
-# Test 43: Both scripts pass --set-string gpu.enabled to helm
-install_gpu_set=$(grep -c '\-\-set-string onelens-agent.gpu.enabled' "$ROOT/install.sh" || true)
-patching_gpu_set=$(grep -c '\-\-set-string onelens-agent.gpu.enabled' "$ROOT/src/patching.sh" || true)
-assert_gt "$install_gpu_set" "0" "install.sh passes --set-string gpu.enabled to helm"
-assert_gt "$patching_gpu_set" "0" "patching.sh passes --set-string gpu.enabled to helm"
+# Test 43: DCGM is deployed via kubectl apply, NOT via helm --set
+# This ensures DCGM failures cannot block helm --wait and cascade to all components
+install_dcgm_kubectl=$(grep -c 'kubectl apply.*DCGM_EOF' "$ROOT/install.sh" || true)
+patching_dcgm_kubectl=$(grep -c 'kubectl apply.*DCGM_EOF' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_dcgm_kubectl" "0" "install.sh deploys DCGM via kubectl apply (not helm)"
+assert_gt "$patching_dcgm_kubectl" "0" "patching.sh deploys DCGM via kubectl apply (not helm)"
 
-# Test 44: Both scripts use --set-string (not --set) for gpu.enabled
-# Using --set would convert "false" to Go boolean, breaking the template ne comparison
-install_gpu_plain_set=$(grep 'onelens-agent.gpu.enabled' "$ROOT/install.sh" | grep -cv '\-\-set-string' || true)
-patching_gpu_plain_set=$(grep 'onelens-agent.gpu.enabled' "$ROOT/src/patching.sh" | grep -cv '\-\-set-string' || true)
-assert_eq "$install_gpu_plain_set" "0" "install.sh does not use --set (plain) for gpu.enabled"
-assert_eq "$patching_gpu_plain_set" "0" "patching.sh does not use --set (plain) for gpu.enabled"
+# Test 44: Neither script passes gpu.enabled to helm (decoupled)
+install_gpu_helm=$(grep 'onelens-agent.gpu.enabled' "$ROOT/install.sh" | grep -c '\-\-set' || true)
+patching_gpu_helm=$(grep 'onelens-agent.gpu.enabled' "$ROOT/src/patching.sh" | grep -c '\-\-set' || true)
+assert_eq "$install_gpu_helm" "0" "install.sh does NOT pass gpu.enabled to helm"
+assert_eq "$patching_gpu_helm" "0" "patching.sh does NOT pass gpu.enabled to helm"
 
-# Test 45: Both scripts have DCGM image override in air-gapped section
-install_dcgm_airgap=$(sed -n '/Air-gapped: override all image/,/^fi$/p' "$ROOT/install.sh" | grep -c 'dcgm-exporter' || true)
-patching_dcgm_airgap=$(sed -n '/Air-gapped: override all image/,/^fi$/p' "$ROOT/src/patching.sh" | grep -c 'dcgm-exporter' || true)
-assert_gt "$install_dcgm_airgap" "0" "install.sh has DCGM image override in air-gapped section"
-assert_gt "$patching_dcgm_airgap" "0" "patching.sh has DCGM image override in air-gapped section"
+# Test 45: Both scripts have DCGM image from nvcr.io (NVIDIA's registry) in kubectl apply block
+install_dcgm_img=$(sed -n '/GPU Phase 2: deploy/,/DCGM_EOF/p' "$ROOT/install.sh" | grep -c 'nvcr.io/nvidia' || true)
+patching_dcgm_img=$(sed -n '/GPU Phase 2: deploy/,/DCGM_EOF/p' "$ROOT/src/patching.sh" | grep -c 'nvcr.io/nvidia' || true)
+assert_gt "$install_dcgm_img" "0" "install.sh DCGM image is from nvcr.io"
+assert_gt "$patching_dcgm_img" "0" "patching.sh DCGM image is from nvcr.io"
 
 # Test 46: Both scripts check DCGM_PODS_OTHER in the GPU_ENABLED resolution block
 install_pods_other_check=$(sed -n '/GPU Phase 2: resolve gpu.enabled/,/^$/p' "$ROOT/install.sh" | grep -c 'DCGM_PODS_OTHER' || true)
@@ -405,6 +405,24 @@ patching_gpu_override=$(grep -c 'GPU_ENABLED_OVERRIDE' "$ROOT/src/patching.sh" |
 install_gpu_override=$(grep -c 'GPU_ENABLED_OVERRIDE' "$ROOT/install.sh" || true)
 assert_gt "$patching_gpu_override" "0" "patching.sh reads GPU_ENABLED_OVERRIDE from existing release"
 assert_eq "$install_gpu_override" "0" "install.sh does NOT read GPU_ENABLED_OVERRIDE (fresh install)"
+
+# Test 48: Both scripts detect GPU Operator DCGM (app.kubernetes.io/component label)
+install_gpu_operator=$(grep -c 'app.kubernetes.io/component=dcgm-exporter' "$ROOT/install.sh" || true)
+patching_gpu_operator=$(grep -c 'app.kubernetes.io/component=dcgm-exporter' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_gpu_operator" "0" "install.sh detects GPU Operator-managed DCGM"
+assert_gt "$patching_gpu_operator" "0" "patching.sh detects GPU Operator-managed DCGM"
+
+# Test 49: Both scripts have non-fatal DCGM deployment (WARNING on failure, not exit)
+install_dcgm_nonfatal=$(sed -n '/GPU Phase 2: deploy/,/^fi$/p' "$ROOT/install.sh" | grep -c 'WARNING.*DCGM.*failed' || true)
+patching_dcgm_nonfatal=$(sed -n '/GPU Phase 2: deploy/,/^fi$/p' "$ROOT/src/patching.sh" | grep -c 'WARNING.*DCGM.*failed' || true)
+assert_gt "$install_dcgm_nonfatal" "0" "install.sh DCGM failure is non-fatal (WARNING)"
+assert_gt "$patching_dcgm_nonfatal" "0" "patching.sh DCGM failure is non-fatal (WARNING)"
+
+# Test 50: Both scripts have air-gapped DCGM image override in kubectl apply block
+install_dcgm_airgap=$(sed -n '/GPU Phase 2: deploy/,/DCGM_EOF/p' "$ROOT/install.sh" | grep -c 'REGISTRY_URL' || true)
+patching_dcgm_airgap=$(sed -n '/GPU Phase 2: deploy/,/DCGM_EOF/p' "$ROOT/src/patching.sh" | grep -c 'REGISTRY_URL' || true)
+assert_gt "$install_dcgm_airgap" "0" "install.sh has air-gapped DCGM image override"
+assert_gt "$patching_dcgm_airgap" "0" "patching.sh has air-gapped DCGM image override"
 
 test_summary
 exit $?

--- a/tests/test-parity.sh
+++ b/tests/test-parity.sh
@@ -364,5 +364,47 @@ assert_eq "$install_prof_check" "0" "install.sh does NOT have Prometheus PROF ch
 patching_prom_guard=$(grep 'DCGM_PODS_TOTAL' "$ROOT/src/patching.sh" | grep -c 'PROM_QUERY_URL' || true)
 assert_gt "$patching_prom_guard" "0" "patching.sh Stage 2 guards on PROM_QUERY_URL availability"
 
+# ---------------------------------------------------------------------------
+# GPU Phase 2: conditional DCGM DaemonSet — parity tests
+# ---------------------------------------------------------------------------
+
+# Test 42: Both scripts initialize GPU_ENABLED variable
+install_gpu_enabled_init=$(grep -c '^GPU_ENABLED="false"' "$ROOT/install.sh" || true)
+patching_gpu_enabled_init=$(grep -c '^GPU_ENABLED="false"' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_gpu_enabled_init" "0" "install.sh initializes GPU_ENABLED"
+assert_gt "$patching_gpu_enabled_init" "0" "patching.sh initializes GPU_ENABLED"
+
+# Test 43: Both scripts pass --set-string gpu.enabled to helm
+install_gpu_set=$(grep -c '\-\-set-string onelens-agent.gpu.enabled' "$ROOT/install.sh" || true)
+patching_gpu_set=$(grep -c '\-\-set-string onelens-agent.gpu.enabled' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_gpu_set" "0" "install.sh passes --set-string gpu.enabled to helm"
+assert_gt "$patching_gpu_set" "0" "patching.sh passes --set-string gpu.enabled to helm"
+
+# Test 44: Both scripts use --set-string (not --set) for gpu.enabled
+# Using --set would convert "false" to Go boolean, breaking the template ne comparison
+install_gpu_plain_set=$(grep 'onelens-agent.gpu.enabled' "$ROOT/install.sh" | grep -cv '\-\-set-string' || true)
+patching_gpu_plain_set=$(grep 'onelens-agent.gpu.enabled' "$ROOT/src/patching.sh" | grep -cv '\-\-set-string' || true)
+assert_eq "$install_gpu_plain_set" "0" "install.sh does not use --set (plain) for gpu.enabled"
+assert_eq "$patching_gpu_plain_set" "0" "patching.sh does not use --set (plain) for gpu.enabled"
+
+# Test 45: Both scripts have DCGM image override in air-gapped section
+install_dcgm_airgap=$(sed -n '/Air-gapped: override all image/,/^fi$/p' "$ROOT/install.sh" | grep -c 'dcgm-exporter' || true)
+patching_dcgm_airgap=$(sed -n '/Air-gapped: override all image/,/^fi$/p' "$ROOT/src/patching.sh" | grep -c 'dcgm-exporter' || true)
+assert_gt "$install_dcgm_airgap" "0" "install.sh has DCGM image override in air-gapped section"
+assert_gt "$patching_dcgm_airgap" "0" "patching.sh has DCGM image override in air-gapped section"
+
+# Test 46: Both scripts check DCGM_PODS_OTHER in the GPU_ENABLED resolution block
+install_pods_other_check=$(sed -n '/GPU Phase 2: resolve gpu.enabled/,/^$/p' "$ROOT/install.sh" | grep -c 'DCGM_PODS_OTHER' || true)
+patching_pods_other_check=$(sed -n '/GPU Phase 2: resolve gpu.enabled/,/^$/p' "$ROOT/src/patching.sh" | grep -c 'DCGM_PODS_OTHER' || true)
+assert_gt "$install_pods_other_check" "0" "install.sh checks DCGM_PODS_OTHER for GPU_ENABLED resolution"
+assert_gt "$patching_pods_other_check" "0" "patching.sh checks DCGM_PODS_OTHER for GPU_ENABLED resolution"
+
+# Test 47: Only patching.sh reads GPU_ENABLED_OVERRIDE from existing release
+# install.sh is a fresh install — no existing release to read from
+patching_gpu_override=$(grep -c 'GPU_ENABLED_OVERRIDE' "$ROOT/src/patching.sh" || true)
+install_gpu_override=$(grep -c 'GPU_ENABLED_OVERRIDE' "$ROOT/install.sh" || true)
+assert_gt "$patching_gpu_override" "0" "patching.sh reads GPU_ENABLED_OVERRIDE from existing release"
+assert_eq "$install_gpu_override" "0" "install.sh does NOT read GPU_ENABLED_OVERRIDE (fresh install)"
+
 test_summary
 exit $?


### PR DESCRIPTION
## Summary
- Auto-detect GPU nodes and deploy DCGM exporter via `kubectl apply` after helm upgrade
- DCGM failures are **non-fatal** (WARNING log, continues) — cannot block helm `--wait` or cascade to other components
- Broader DCGM detection: standalone (`app=nvidia-dcgm-exporter`) + GPU Operator (`app.kubernetes.io/component=dcgm-exporter`)
- Image from `nvcr.io/nvidia/k8s/dcgm-exporter`, air-gapped override via `$REGISTRY_URL`
- Cleanup uses `managed-by=onelens` label — won't touch customer-managed DCGM
- Customer opt-out: set `gpu.enabled: "false"` in helm values

## Safety design
DCGM is deployed via `kubectl apply` AFTER successful `helm upgrade`, not via a chart template. This means:
- PSA blocking SYS_ADMIN → DCGM fails, everything else works
- Image pull fails (nvcr.io unreachable) → DCGM fails, everything else works
- DCGM OOM → DCGM restarts, everything else works
- Non-GPU clusters → no DCGM resources, ~50ms overhead from one extra kubectl call

## Files changed
- `src/patching.sh` — GPU_ENABLED resolution + kubectl apply DCGM after helm
- `install.sh` — same
- `patching.sh` — rebuilt
- `globalvalues.yaml` — gpu section (opt-out signaling)
- `charts/onelens-agent/values.yaml` — gpu section (opt-out signaling)
- `scripts/airgapped/airgapped_migrate_images.sh` — DCGM image in mirror list
- `tests/test-parity.sh` — 18 new GPU parity tests
- `tests/test-build.sh` — 9 new GPU build tests
- `tests/test-airgapped.sh` — flag count update

## Test plan
- [ ] 827 tests passing (27 new GPU tests)
- [ ] Validated on prod-qjzwwdnpes-k8s-cluster: GPU detection, DCGM deploy, PROF metric in Prometheus
- [ ] Backward compat: `--dry-run` on v2.1.70 chart succeeds
- [ ] Non-GPU cluster: no DCGM resources, no log noise
- [ ] Two independent staff-engineer reviews passed