### PR TITLE
feat(gpu): DCGM lifecycle in healthcheck path (entrypoint.sh)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -170,19 +170,38 @@ elif [ "$deployment_type" = "cronjob" ]; then
             _gpu_node_count=$(echo "$_gpu_caps" | awk '$1 != "<none>" && $1+0 > 0 {c++} END {print c+0}')
         fi
         if [ "$_gpu_node_count" -gt 0 ]; then
+            # Discover GPU node label for DaemonSet scheduling
+            _gpu_label_key=""
+            _gpu_node_name=$(kubectl get nodes --chunk-size=100 -o custom-columns='NAME:.metadata.name,GPU:.status.capacity.nvidia\.com/gpu' --no-headers 2>/dev/null | awk '$2 != "<none>" && $2+0 > 0 {print $1; exit}' || true)
+            if [ -n "$_gpu_node_name" ]; then
+                _gpu_node_json=$(kubectl get node "$_gpu_node_name" -o json 2>/dev/null || true)
+                # Search for any label starting with nvidia.com/gpu (covers all NVIDIA conventions)
+                _gpu_label_key=$(echo "$_gpu_node_json" | jq -r '.metadata.labels | keys[] | select(startswith("nvidia.com/gpu"))' 2>/dev/null | head -1 || true)
+                # Fallback: cloud-specific labels
+                if [ -z "$_gpu_label_key" ]; then
+                    for _label in "feature.node.kubernetes.io/pci-10de.present" "cloud.google.com/gke-accelerator"; do
+                        _val=$(echo "$_gpu_node_json" | jq -r --arg l "$_label" '.metadata.labels[$l] // empty' 2>/dev/null || true)
+                        if [ -n "$_val" ]; then
+                            _gpu_label_key="$_label"
+                            break
+                        fi
+                    done
+                fi
+            fi
+
             # Check for customer-managed DCGM (standalone + GPU Operator labels)
             _dcgm_by_app=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
             _dcgm_by_operator=$(kubectl get pods --all-namespaces -l app.kubernetes.io/component=dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
             _dcgm_other=$(( _dcgm_by_app > _dcgm_by_operator ? _dcgm_by_app : _dcgm_by_operator ))
-            if [ "$_dcgm_other" -eq 0 ]; then
-                # No customer DCGM — ensure ours exists
+            if [ "$_dcgm_other" -eq 0 ] && [ -n "$_gpu_label_key" ]; then
+                # No customer DCGM + known label found — ensure ours exists
                 if ! kubectl get ds nvidia-dcgm-exporter -n onelens-agent --no-headers 2>/dev/null | grep -q .; then
                     _registry_url=$(kubectl get cm onelens-agent-env -n onelens-agent -o jsonpath='{.data.REGISTRY_URL}' 2>/dev/null || true)
                     _dcgm_image="nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
                     if [ -n "$_registry_url" ]; then
                         _dcgm_image="$_registry_url/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
                     fi
-                    echo "GPU: deploying DCGM exporter ($_gpu_node_count GPU nodes detected)"
+                    echo "GPU: deploying DCGM exporter ($_gpu_node_count GPU nodes, label: $_gpu_label_key)"
                     kubectl apply -n onelens-agent -f - <<DCGM_EOF 2>&1 || echo "  WARNING: DCGM deploy failed (non-fatal)"
 apiVersion: apps/v1
 kind: DaemonSet
@@ -201,8 +220,13 @@ spec:
       labels:
         app: nvidia-dcgm-exporter
     spec:
-      nodeSelector:
-        nvidia.com/gpu.present: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: $_gpu_label_key
+                    operator: Exists
       tolerations:
         - operator: Exists
       containers:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,10 +98,11 @@ elif [ "$deployment_type" = "cronjob" ]; then
     UNHEALTHY_REASONS=""
 
     # Check 1: All pods Running and Ready
-    # Filter out terminal job/cronjob pods (Completed, Error) — these are not long-running
-    # workloads and should not trigger remediation.
+    # Filter out terminal job/cronjob pods (Completed, Error) and DCGM exporter pods.
+    # DCGM is a monitoring sidecar — its failures (PSA, image pull) should not
+    # trigger full patching.sh remediation for core components.
     NOT_READY=$(kubectl get pods -n onelens-agent --no-headers 2>/dev/null \
-        | grep -vE 'Completed|Error|Terminating' \
+        | grep -vE 'Completed|Error|Terminating|nvidia-dcgm-exporter' \
         | awk '{split($2,a,"/"); if (a[1] != a[2] || $3 != "Running") print $1 " (" $3 ")"}' || true)
     if [ -n "$NOT_READY" ]; then
         UNHEALTHY_REASONS="${UNHEALTHY_REASONS}Pods not ready: ${NOT_READY}\n"
@@ -158,6 +159,109 @@ elif [ "$deployment_type" = "cronjob" ]; then
         curl -s --max-time 10 --location --request PUT "${API_ENDPOINT}/v1/kubernetes/cluster-version" \
             --header 'Content-Type: application/json' \
             --data "$payload" >/dev/null 2>&1 || true
+
+        # --- GPU: DCGM exporter lifecycle (runs every healthcheck cycle) ---
+        # Ensures DCGM DaemonSet exists when GPU nodes are present. Once deployed,
+        # the DaemonSet controller handles spot/scale churn automatically.
+        # Non-fatal — failures don't affect healthcheck result.
+        _gpu_caps=$(kubectl get nodes --chunk-size=100 -o custom-columns='GPU:.status.capacity.nvidia\.com/gpu' --no-headers 2>/dev/null || true)
+        _gpu_node_count=0
+        if [ -n "$_gpu_caps" ]; then
+            _gpu_node_count=$(echo "$_gpu_caps" | awk '$1 != "<none>" && $1+0 > 0 {c++} END {print c+0}')
+        fi
+        if [ "$_gpu_node_count" -gt 0 ]; then
+            # Check for customer-managed DCGM (standalone + GPU Operator labels)
+            _dcgm_by_app=$(kubectl get pods --all-namespaces -l app=nvidia-dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+            _dcgm_by_operator=$(kubectl get pods --all-namespaces -l app.kubernetes.io/component=dcgm-exporter --no-headers 2>/dev/null | grep -v "^onelens-agent " | wc -l | tr -d '[:space:]')
+            _dcgm_other=$(( _dcgm_by_app > _dcgm_by_operator ? _dcgm_by_app : _dcgm_by_operator ))
+            if [ "$_dcgm_other" -eq 0 ]; then
+                # No customer DCGM — ensure ours exists
+                if ! kubectl get ds nvidia-dcgm-exporter -n onelens-agent --no-headers 2>/dev/null | grep -q .; then
+                    _registry_url=$(kubectl get cm onelens-agent-env -n onelens-agent -o jsonpath='{.data.REGISTRY_URL}' 2>/dev/null || true)
+                    _dcgm_image="nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
+                    if [ -n "$_registry_url" ]; then
+                        _dcgm_image="$_registry_url/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
+                    fi
+                    echo "GPU: deploying DCGM exporter ($_gpu_node_count GPU nodes detected)"
+                    kubectl apply -n onelens-agent -f - <<DCGM_EOF 2>&1 || echo "  WARNING: DCGM deploy failed (non-fatal)"
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-dcgm-exporter
+  namespace: onelens-agent
+  labels:
+    app: nvidia-dcgm-exporter
+    managed-by: onelens
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-dcgm-exporter
+  template:
+    metadata:
+      labels:
+        app: nvidia-dcgm-exporter
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: dcgm-exporter
+          image: $_dcgm_image
+          args: ["-f", "/etc/dcgm-exporter/dcp-metrics-included.csv"]
+          ports:
+            - name: metrics
+              containerPort: 9400
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN"]
+          env:
+            - name: DCGM_EXPORTER_KUBERNETES
+              value: "true"
+            - name: DCGM_EXPORTER_LISTEN
+              value: ":9400"
+          volumeMounts:
+            - name: pod-resources
+              mountPath: /var/lib/kubelet/pod-resources
+              readOnly: true
+      volumes:
+        - name: pod-resources
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nvidia-dcgm-exporter
+  namespace: onelens-agent
+  labels:
+    app: nvidia-dcgm-exporter
+    managed-by: onelens
+spec:
+  selector:
+    app: nvidia-dcgm-exporter
+  ports:
+    - name: gpu-metrics
+      port: 9400
+      targetPort: 9400
+DCGM_EOF
+                fi
+            fi
+        else
+            # No GPU nodes — clean up our DCGM if it exists
+            if kubectl get ds nvidia-dcgm-exporter -n onelens-agent -l managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
+                echo "GPU: cleaning up DCGM exporter (no GPU nodes)"
+                kubectl delete ds nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
+                kubectl delete svc nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
+            fi
+        fi
 
         exit 0
     fi

--- a/install.sh
+++ b/install.sh
@@ -403,6 +403,32 @@ if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     else
         echo "DCGM exporter: $DCGM_PODS_OURS pods (in onelens-agent namespace)"
     fi
+
+    # Discover GPU node label for DCGM DaemonSet scheduling.
+    GPU_NODE_LABEL_KEY=""
+    _gpu_node_name=$(kubectl get nodes --chunk-size=100 -o custom-columns='NAME:.metadata.name,GPU:.status.capacity.nvidia\.com/gpu' --no-headers 2>/dev/null | awk '$2 != "<none>" && $2+0 > 0 {print $1; exit}' || true)
+    if [ -n "$_gpu_node_name" ]; then
+        _gpu_node_json=$(kubectl get node "$_gpu_node_name" -o json 2>/dev/null || true)
+        # Search for any label starting with nvidia.com/gpu (covers all NVIDIA conventions)
+        GPU_NODE_LABEL_KEY=$(echo "$_gpu_node_json" | jq -r '.metadata.labels | keys[] | select(startswith("nvidia.com/gpu"))' 2>/dev/null | head -1 || true)
+        # Fallback: cloud-specific labels
+        if [ -z "$GPU_NODE_LABEL_KEY" ]; then
+            for _label in "feature.node.kubernetes.io/pci-10de.present" "cloud.google.com/gke-accelerator"; do
+                _val=$(echo "$_gpu_node_json" | jq -r --arg l "$_label" '.metadata.labels[$l] // empty' 2>/dev/null || true)
+                if [ -n "$_val" ]; then
+                    GPU_NODE_LABEL_KEY="$_label"
+                    break
+                fi
+            done
+        fi
+        if [ -n "$GPU_NODE_LABEL_KEY" ]; then
+            echo "GPU node label: $GPU_NODE_LABEL_KEY (from node $_gpu_node_name)"
+        else
+            echo "WARNING: GPU nodes detected but no GPU scheduling label found on node $_gpu_node_name"
+            echo "  DCGM exporter cannot be deployed. GPU cost metrics still work."
+        fi
+    fi
+
     echo "GPU_MONITORING_STATUS=$GPU_MONITORING_STATUS"
 fi
 
@@ -814,12 +840,12 @@ echo "Helm install succeeded. Resources submitted to cluster."
 # --- GPU Phase 2: deploy DCGM exporter via kubectl (decoupled from helm) ---
 # Deployed separately so DCGM failures (PSA blocking SYS_ADMIN, image pull, etc.)
 # cannot block the main helm install.
-if [ "$GPU_ENABLED" = "true" ]; then
+if [ "$GPU_ENABLED" = "true" ] && [ -n "$GPU_NODE_LABEL_KEY" ]; then
     DCGM_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
     if [ -n "$REGISTRY_URL" ]; then
         DCGM_IMAGE="$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
     fi
-    echo "Deploying DCGM exporter DaemonSet (image: $DCGM_IMAGE)"
+    echo "Deploying DCGM exporter DaemonSet (label: $GPU_NODE_LABEL_KEY, image: $DCGM_IMAGE)"
     if kubectl apply -n onelens-agent -f - <<DCGM_EOF 2>&1
 apiVersion: apps/v1
 kind: DaemonSet
@@ -838,8 +864,13 @@ spec:
       labels:
         app: nvidia-dcgm-exporter
     spec:
-      nodeSelector:
-        nvidia.com/gpu.present: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: $GPU_NODE_LABEL_KEY
+                    operator: Exists
       tolerations:
         - operator: Exists
       containers:

--- a/patching.sh
+++ b/patching.sh
@@ -1207,6 +1207,34 @@ if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     else
         echo "DCGM exporter: $DCGM_PODS_OURS pods (in onelens-agent namespace)"
     fi
+
+    # Discover GPU node label for DCGM DaemonSet scheduling.
+    # Different clusters use different labels: NFD sets nvidia.com/gpu.present,
+    # some AMIs set it too, GKE uses cloud.google.com/gke-accelerator, etc.
+    # We check a priority list and use the first match.
+    GPU_NODE_LABEL_KEY=""
+    _gpu_node_name=$(kubectl get nodes --chunk-size=100 -o custom-columns='NAME:.metadata.name,GPU:.status.capacity.nvidia\.com/gpu' --no-headers 2>/dev/null | awk '$2 != "<none>" && $2+0 > 0 {print $1; exit}' || true)
+    if [ -n "$_gpu_node_name" ]; then
+        _gpu_node_json=$(kubectl get node "$_gpu_node_name" -o json 2>/dev/null || true)
+        # Search for any label starting with nvidia.com/gpu (covers all NVIDIA conventions)
+        GPU_NODE_LABEL_KEY=$(echo "$_gpu_node_json" | jq -r '.metadata.labels | keys[] | select(startswith("nvidia.com/gpu"))' 2>/dev/null | head -1 || true)
+        # Fallback: cloud-specific labels
+        if [ -z "$GPU_NODE_LABEL_KEY" ]; then
+            for _label in "feature.node.kubernetes.io/pci-10de.present" "cloud.google.com/gke-accelerator"; do
+                _val=$(echo "$_gpu_node_json" | jq -r --arg l "$_label" '.metadata.labels[$l] // empty' 2>/dev/null || true)
+                if [ -n "$_val" ]; then
+                    GPU_NODE_LABEL_KEY="$_label"
+                    break
+                fi
+            done
+        fi
+        if [ -n "$GPU_NODE_LABEL_KEY" ]; then
+            echo "GPU node label: $GPU_NODE_LABEL_KEY (from node $_gpu_node_name)"
+        else
+            echo "WARNING: GPU nodes detected but no GPU scheduling label found on node $_gpu_node_name"
+            echo "  DCGM exporter cannot be deployed. GPU cost metrics still work."
+        fi
+    fi
 fi
 
 # --- Resource tier selection ---
@@ -3096,12 +3124,12 @@ UPGRADE_EXIT=$?
 # --- GPU Phase 2: deploy/cleanup DCGM exporter via kubectl (decoupled from helm) ---
 # Deployed separately so DCGM failures (PSA blocking SYS_ADMIN, image pull, etc.)
 # cannot block the main helm upgrade via --wait timeout.
-if [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_ENABLED" = "true" ]; then
+if [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_ENABLED" = "true" ] && [ -n "$GPU_NODE_LABEL_KEY" ]; then
     DCGM_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
     if [ -n "$REGISTRY_URL" ]; then
         DCGM_IMAGE="$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
     fi
-    echo "Deploying DCGM exporter DaemonSet (image: $DCGM_IMAGE)"
+    echo "Deploying DCGM exporter DaemonSet (label: $GPU_NODE_LABEL_KEY, image: $DCGM_IMAGE)"
     if kubectl apply -n onelens-agent -f - <<DCGM_EOF 2>&1
 apiVersion: apps/v1
 kind: DaemonSet
@@ -3120,8 +3148,13 @@ spec:
       labels:
         app: nvidia-dcgm-exporter
     spec:
-      nodeSelector:
-        nvidia.com/gpu.present: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: $GPU_NODE_LABEL_KEY
+                    operator: Exists
       tolerations:
         - operator: Exists
       containers:

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -383,6 +383,34 @@ if [ "$GPU_NODE_COUNT" -gt 0 ]; then
     else
         echo "DCGM exporter: $DCGM_PODS_OURS pods (in onelens-agent namespace)"
     fi
+
+    # Discover GPU node label for DCGM DaemonSet scheduling.
+    # Different clusters use different labels: NFD sets nvidia.com/gpu.present,
+    # some AMIs set it too, GKE uses cloud.google.com/gke-accelerator, etc.
+    # We check a priority list and use the first match.
+    GPU_NODE_LABEL_KEY=""
+    _gpu_node_name=$(kubectl get nodes --chunk-size=100 -o custom-columns='NAME:.metadata.name,GPU:.status.capacity.nvidia\.com/gpu' --no-headers 2>/dev/null | awk '$2 != "<none>" && $2+0 > 0 {print $1; exit}' || true)
+    if [ -n "$_gpu_node_name" ]; then
+        _gpu_node_json=$(kubectl get node "$_gpu_node_name" -o json 2>/dev/null || true)
+        # Search for any label starting with nvidia.com/gpu (covers all NVIDIA conventions)
+        GPU_NODE_LABEL_KEY=$(echo "$_gpu_node_json" | jq -r '.metadata.labels | keys[] | select(startswith("nvidia.com/gpu"))' 2>/dev/null | head -1 || true)
+        # Fallback: cloud-specific labels
+        if [ -z "$GPU_NODE_LABEL_KEY" ]; then
+            for _label in "feature.node.kubernetes.io/pci-10de.present" "cloud.google.com/gke-accelerator"; do
+                _val=$(echo "$_gpu_node_json" | jq -r --arg l "$_label" '.metadata.labels[$l] // empty' 2>/dev/null || true)
+                if [ -n "$_val" ]; then
+                    GPU_NODE_LABEL_KEY="$_label"
+                    break
+                fi
+            done
+        fi
+        if [ -n "$GPU_NODE_LABEL_KEY" ]; then
+            echo "GPU node label: $GPU_NODE_LABEL_KEY (from node $_gpu_node_name)"
+        else
+            echo "WARNING: GPU nodes detected but no GPU scheduling label found on node $_gpu_node_name"
+            echo "  DCGM exporter cannot be deployed. GPU cost metrics still work."
+        fi
+    fi
 fi
 
 # --- Resource tier selection ---
@@ -2272,12 +2300,12 @@ UPGRADE_EXIT=$?
 # --- GPU Phase 2: deploy/cleanup DCGM exporter via kubectl (decoupled from helm) ---
 # Deployed separately so DCGM failures (PSA blocking SYS_ADMIN, image pull, etc.)
 # cannot block the main helm upgrade via --wait timeout.
-if [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_ENABLED" = "true" ]; then
+if [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_ENABLED" = "true" ] && [ -n "$GPU_NODE_LABEL_KEY" ]; then
     DCGM_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
     if [ -n "$REGISTRY_URL" ]; then
         DCGM_IMAGE="$REGISTRY_URL/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04"
     fi
-    echo "Deploying DCGM exporter DaemonSet (image: $DCGM_IMAGE)"
+    echo "Deploying DCGM exporter DaemonSet (label: $GPU_NODE_LABEL_KEY, image: $DCGM_IMAGE)"
     if kubectl apply -n onelens-agent -f - <<DCGM_EOF 2>&1
 apiVersion: apps/v1
 kind: DaemonSet
@@ -2296,8 +2324,13 @@ spec:
       labels:
         app: nvidia-dcgm-exporter
     spec:
-      nodeSelector:
-        nvidia.com/gpu.present: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: $GPU_NODE_LABEL_KEY
+                    operator: Exists
       tolerations:
         - operator: Exists
       containers:

--- a/tests/test-entrypoint.sh
+++ b/tests/test-entrypoint.sh
@@ -187,6 +187,44 @@ else
 fi
 
 ###############################################################################
+# GPU: DCGM lifecycle in healthcheck
+###############################################################################
+
+# DCGM pods excluded from NOT_READY health check
+dcgm_excluded=$(sed -n '/NOT_READY=/,/|| true)/p' "$ENTRYPOINT" | grep -c 'nvidia-dcgm-exporter' || true)
+assert_gt "$dcgm_excluded" "0" "entrypoint.sh excludes DCGM pods from NOT_READY health check"
+
+# DCGM lifecycle block exists in healthcheck healthy path
+dcgm_lifecycle=$(grep -c 'GPU: DCGM exporter lifecycle' "$ENTRYPOINT" || true)
+assert_gt "$dcgm_lifecycle" "0" "entrypoint.sh has DCGM lifecycle block in healthcheck"
+
+# DCGM detection uses same GPU capacity check as patching.sh
+dcgm_gpu_detect=$(grep -c 'status.capacity.nvidia' "$ENTRYPOINT" || true)
+assert_gt "$dcgm_gpu_detect" "0" "entrypoint.sh detects GPU nodes via capacity"
+
+# DCGM detection checks both standalone and GPU Operator labels
+dcgm_standalone=$(grep -c 'app=nvidia-dcgm-exporter' "$ENTRYPOINT" || true)
+dcgm_operator=$(grep -c 'app.kubernetes.io/component=dcgm-exporter' "$ENTRYPOINT" || true)
+assert_gt "$dcgm_standalone" "0" "entrypoint.sh checks standalone DCGM label"
+assert_gt "$dcgm_operator" "0" "entrypoint.sh checks GPU Operator DCGM label"
+
+# DCGM deploy is non-fatal
+dcgm_nonfatal=$(grep -c 'WARNING.*DCGM.*failed.*non-fatal' "$ENTRYPOINT" || true)
+assert_gt "$dcgm_nonfatal" "0" "entrypoint.sh DCGM deploy failure is non-fatal"
+
+# DCGM cleanup uses managed-by=onelens label guard
+dcgm_label_guard=$(grep -c 'managed-by=onelens' "$ENTRYPOINT" || true)
+assert_gt "$dcgm_label_guard" "0" "entrypoint.sh DCGM cleanup uses managed-by=onelens label"
+
+# DCGM air-gapped: reads REGISTRY_URL from ConfigMap
+dcgm_airgap=$(grep -c 'onelens-agent-env.*REGISTRY_URL' "$ENTRYPOINT" || true)
+assert_gt "$dcgm_airgap" "0" "entrypoint.sh reads REGISTRY_URL from ConfigMap for air-gapped"
+
+# DCGM manifest has nodeSelector for GPU nodes
+dcgm_nodeselector=$(sed -n '/DCGM_EOF/,/DCGM_EOF/p' "$ENTRYPOINT" | grep -c 'nvidia.com/gpu.present' || true)
+assert_gt "$dcgm_nodeselector" "0" "entrypoint.sh DCGM manifest has GPU nodeSelector"
+
+###############################################################################
 # Summary
 ###############################################################################
 test_summary

--- a/tests/test-entrypoint.sh
+++ b/tests/test-entrypoint.sh
@@ -220,9 +220,13 @@ assert_gt "$dcgm_label_guard" "0" "entrypoint.sh DCGM cleanup uses managed-by=on
 dcgm_airgap=$(grep -c 'onelens-agent-env.*REGISTRY_URL' "$ENTRYPOINT" || true)
 assert_gt "$dcgm_airgap" "0" "entrypoint.sh reads REGISTRY_URL from ConfigMap for air-gapped"
 
-# DCGM manifest has nodeSelector for GPU nodes
-dcgm_nodeselector=$(sed -n '/DCGM_EOF/,/DCGM_EOF/p' "$ENTRYPOINT" | grep -c 'nvidia.com/gpu.present' || true)
-assert_gt "$dcgm_nodeselector" "0" "entrypoint.sh DCGM manifest has GPU nodeSelector"
+# DCGM manifest uses nodeAffinity with dynamic label (not hardcoded nodeSelector)
+dcgm_affinity=$(sed -n '/DCGM_EOF/,/DCGM_EOF/p' "$ENTRYPOINT" | grep -c 'nodeAffinity' || true)
+assert_gt "$dcgm_affinity" "0" "entrypoint.sh DCGM manifest uses nodeAffinity"
+
+# DCGM label discovery uses prefix search for nvidia.com/gpu labels
+dcgm_label_discovery=$(grep -c 'startswith("nvidia.com/gpu")' "$ENTRYPOINT" || true)
+assert_gt "$dcgm_label_discovery" "0" "entrypoint.sh discovers GPU label dynamically via prefix search"
 
 ###############################################################################
 # Summary

--- a/tests/test-parity.sh
+++ b/tests/test-parity.sh
@@ -424,5 +424,23 @@ patching_dcgm_airgap=$(sed -n '/GPU Phase 2: deploy/,/DCGM_EOF/p' "$ROOT/src/pat
 assert_gt "$install_dcgm_airgap" "0" "install.sh has air-gapped DCGM image override"
 assert_gt "$patching_dcgm_airgap" "0" "patching.sh has air-gapped DCGM image override"
 
+# Test 51: Both scripts discover GPU node label dynamically (not hardcoded nodeSelector)
+install_label_discovery=$(grep -c 'GPU_NODE_LABEL_KEY' "$ROOT/install.sh" || true)
+patching_label_discovery=$(grep -c 'GPU_NODE_LABEL_KEY' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_label_discovery" "0" "install.sh uses dynamic GPU_NODE_LABEL_KEY"
+assert_gt "$patching_label_discovery" "0" "patching.sh uses dynamic GPU_NODE_LABEL_KEY"
+
+# Test 52: Both scripts use nodeAffinity (not nodeSelector) in DCGM manifest
+install_affinity=$(sed -n '/DCGM_EOF/,/DCGM_EOF/p' "$ROOT/install.sh" | grep -c 'nodeAffinity' || true)
+patching_affinity=$(sed -n '/DCGM_EOF/,/DCGM_EOF/p' "$ROOT/src/patching.sh" | grep -c 'nodeAffinity' || true)
+assert_gt "$install_affinity" "0" "install.sh DCGM uses nodeAffinity"
+assert_gt "$patching_affinity" "0" "patching.sh DCGM uses nodeAffinity"
+
+# Test 53: Both scripts use prefix-based nvidia.com/gpu label search
+install_prefix=$(grep -c 'startswith("nvidia.com/gpu")' "$ROOT/install.sh" || true)
+patching_prefix=$(grep -c 'startswith("nvidia.com/gpu")' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_prefix" "0" "install.sh uses prefix search for nvidia.com/gpu labels"
+assert_gt "$patching_prefix" "0" "patching.sh uses prefix search for nvidia.com/gpu labels"
+
 test_summary
 exit $?


### PR DESCRIPTION
## Summary
- Add DCGM DaemonSet deploy/cleanup to the healthcheck path in entrypoint.sh
- Closes the gap where GPU nodes added after the initial patching run never get DCGM
- Once deployed, the DaemonSet controller handles spot/scale churn automatically
- Exclude DCGM pods from NOT_READY health check (prevents false remediation)

## Why
DCGM deploy/cleanup previously only ran inside patching.sh (triggered on version changes or health failures). In healthcheck mode, entrypoint.sh heartbeats and exits — DCGM was never managed. Clusters that added GPU nodes after the v2.1.71 patching run wouldn't get DCGM until the next version bump.

## Design
- Runs every 5-min healthcheck cycle, after health checks pass, before heartbeat
- GPU nodes exist + no customer DCGM + our DaemonSet missing → kubectl apply
- No GPU nodes + our DaemonSet exists → cleanup (managed-by=onelens label guard)
- All failures non-fatal — don't affect healthcheck result
- Air-gapped: reads REGISTRY_URL from onelens-agent-env ConfigMap
- Non-GPU clusters: 2 extra kubectl calls (~100ms), no writes

## Note
entrypoint.sh is baked in the Docker image. This takes effect on the next deployer chart release (requires image rebuild). Existing deployer versions are unaffected.

## Test plan
- [ ] 836 tests passing (9 new entrypoint DCGM tests)
- [ ] Bash syntax valid
- [ ] Heredoc manifest identical to patching.sh and install.sh
- [ ] Staff engineer review passed