### PR TITLE
fix(gpu): chart default gpu.enabled=false mistaken for customer override

### DIFF
--- a/patching.sh
+++ b/patching.sh
@@ -1289,7 +1289,9 @@ if [[ -n "$CURRENT_VALUES" ]] && command -v jq &>/dev/null; then
   REGISTRATION_ID=$(_get '.["onelens-agent"].secrets.REGISTRATION_ID')
   DEFAULT_CLUSTER_ID=$(_get '.["prometheus-opencost-exporter"].opencost.exporter.defaultClusterId')
   REGISTRY_URL=$(_get '.["onelens-agent"].env.REGISTRY_URL')
-  GPU_ENABLED_OVERRIDE=$(_get '.["onelens-agent"].gpu.enabled')
+  # Read gpu.enabled WITHOUT -a flag — only user-supplied values, not chart defaults.
+  # The chart default is "false" which would be mistaken for a customer override with -a.
+  GPU_ENABLED_OVERRIDE=$(helm get values onelens-agent -n onelens-agent -o json 2>/dev/null | jq -r '.["onelens-agent"].gpu.enabled // empty' 2>/dev/null || true)
   # Note: Can't use _get for booleans — jq's `false // empty` returns empty since false is falsy
   PVC_ENABLED=$(echo "$CURRENT_VALUES" | jq -r '.prometheus.server.persistentVolume.enabled // "true"')
 

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -465,7 +465,9 @@ if [[ -n "$CURRENT_VALUES" ]] && command -v jq &>/dev/null; then
   REGISTRATION_ID=$(_get '.["onelens-agent"].secrets.REGISTRATION_ID')
   DEFAULT_CLUSTER_ID=$(_get '.["prometheus-opencost-exporter"].opencost.exporter.defaultClusterId')
   REGISTRY_URL=$(_get '.["onelens-agent"].env.REGISTRY_URL')
-  GPU_ENABLED_OVERRIDE=$(_get '.["onelens-agent"].gpu.enabled')
+  # Read gpu.enabled WITHOUT -a flag — only user-supplied values, not chart defaults.
+  # The chart default is "false" which would be mistaken for a customer override with -a.
+  GPU_ENABLED_OVERRIDE=$(helm get values onelens-agent -n onelens-agent -o json 2>/dev/null | jq -r '.["onelens-agent"].gpu.enabled // empty' 2>/dev/null || true)
   # Note: Can't use _get for booleans — jq's `false // empty` returns empty since false is falsy
   PVC_ENABLED=$(echo "$CURRENT_VALUES" | jq -r '.prometheus.server.persistentVolume.enabled // "true"')
 


### PR DESCRIPTION
## Summary
`helm get values -a` returns chart defaults alongside user-supplied values. The chart default `gpu.enabled="false"` was being treated as a customer override, preventing auto-detection from deploying DCGM on GPU clusters.

## Root cause
patching.sh reads `GPU_ENABLED_OVERRIDE` using `_get()` which queries `CURRENT_VALUES` (from `helm get values -a`). The `-a` flag includes chart defaults. Since `gpu.enabled: "false"` is the chart default, it always appeared as a non-empty, non-"auto" value → override logic kicked in → `GPU_ENABLED=false` → DCGM never deployed.

## Fix
Read `gpu.enabled` from `helm get values` (without `-a`). This only returns user-supplied values. If the customer never explicitly set `gpu.enabled`, it returns empty → auto-detection runs normally.

## Verified
On live test cluster:
- `helm get values -a`: returns `false` (chart default)
- `helm get values` (no -a): returns empty (correct)

## Test plan
- [ ] 843 tests passing