### PR TITLE
fix(gpu): switch DCGM scrape to dns_sd_configs for reliable discovery

### DIFF
--- a/globalvalues.yaml
+++ b/globalvalues.yaml
@@ -299,19 +299,11 @@ prometheus:
       scrape_timeout: 10s
       metrics_path: /metrics
       scheme: http
-      kubernetes_sd_configs:
-        - role: endpoints
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_service_label_app]
-          regex: nvidia-dcgm-exporter
-          action: keep
-        - source_labels: [__meta_kubernetes_endpoint_port_name]
-          regex: gpu-metrics
-          action: keep
-        - source_labels: [__meta_kubernetes_namespace]
-          target_label: namespace
-        - source_labels: [__meta_kubernetes_pod_name]
-          target_label: pod
+      dns_sd_configs:
+        - names:
+            - nvidia-dcgm-exporter.onelens-agent
+          type: A
+          port: 9400
   serverFiles:
     alerting_rules.yml: {}
     alerts: {}

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -989,8 +989,8 @@ fi
 # (bash functions/variables persist in global scope after the block ends).
 if [ "$GPU_NODE_COUNT" -gt 0 ] && [ "$DCGM_PODS_TOTAL" -gt 0 ] 2>/dev/null && [ -n "${PROM_QUERY_URL:-}" ]; then
     PROF_RAW=$(_prom_query_raw 'count(DCGM_FI_PROF_GR_ENGINE_ACTIVE)')
-    PROF_HAS_DATA=$(echo "$PROF_RAW" | grep -c '"value"' || true)
-    if [ "$PROF_HAS_DATA" -gt 0 ]; then
+    PROF_HAS_DATA=$(echo "$PROF_RAW" | grep -c '"value"' | head -1 | tr -d '[:space:]' || echo "0")
+    if [ "${PROF_HAS_DATA:-0}" -gt 0 ] 2>/dev/null; then
         GPU_MONITORING_STATUS="fully_configured"
         echo "GPU monitoring: fully configured (DCGM_FI_PROF_GR_ENGINE_ACTIVE present in Prometheus)"
     else
@@ -2384,6 +2384,33 @@ spec:
 DCGM_EOF
     then
         echo "DCGM exporter kubectl apply: OK"
+        # Patch Prometheus ConfigMap: replace kubernetes_sd_configs DCGM job with dns_sd_configs.
+        # Old deployer images have kubernetes_sd_configs which requires cluster-wide endpoint RBAC
+        # and fails silently on some clusters. dns_sd_configs uses DNS (always works).
+        _prom_cm=$(kubectl get cm onelens-agent-prometheus-server -n onelens-agent -o jsonpath='{.data.prometheus\.yml}' 2>/dev/null || true)
+        _dcgm_block=$(echo "$_prom_cm" | sed -n '/job_name: dcgm-gpu-metrics/,/^    - job_name:\|^  serverFiles:/p' 2>/dev/null || true)
+        if echo "$_dcgm_block" | grep -q 'kubernetes_sd_configs' 2>/dev/null; then
+            echo "Patching Prometheus scrape config: dcgm-gpu-metrics → dns_sd_configs"
+            _prom_cm_fixed=$(echo "$_prom_cm" | sed '/- job_name: dcgm-gpu-metrics/,/^    - job_name:\|^  serverFiles:/c\
+    - job_name: dcgm-gpu-metrics\
+      honor_labels: true\
+      scrape_interval: 30s\
+      scrape_timeout: 10s\
+      metrics_path: /metrics\
+      scheme: http\
+      dns_sd_configs:\
+        - names:\
+            - nvidia-dcgm-exporter.onelens-agent\
+          type: A\
+          port: 9400')
+            if [ -n "$_prom_cm_fixed" ]; then
+                echo "$_prom_cm_fixed" > /tmp/prom-config-patched.yml
+                kubectl create cm onelens-agent-prometheus-server -n onelens-agent \
+                    --from-file=prometheus.yml=/tmp/prom-config-patched.yml \
+                    --dry-run=client -o yaml 2>/dev/null | kubectl apply -f - 2>&1 || echo "  WARNING: Prometheus ConfigMap patch failed (non-fatal)"
+                rm -f /tmp/prom-config-patched.yml
+            fi
+        fi
     else
         echo "WARNING: DCGM exporter kubectl apply failed — GPU utilization monitoring unavailable"
         echo "  This does not affect other OneLens components."
@@ -2453,8 +2480,9 @@ if [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_NODE_COUNT" -gt 0 ]; then
     # Prometheus PROF metric
     if [ -n "${PROM_QUERY_URL:-}" ]; then
         _prof_raw=$(_prom_query_raw 'count(DCGM_FI_PROF_GR_ENGINE_ACTIVE)' 2>/dev/null || true)
-        _prof_has=$(echo "$_prof_raw" | grep -c '"value"' 2>/dev/null || echo "0")
-        echo "Prometheus PROF metric: $([ "$_prof_has" -gt 0 ] && echo 'PRESENT' || echo 'NOT FOUND')"
+        _prof_has=$(echo "$_prof_raw" | grep -c '"value"' 2>/dev/null | head -1 || echo "0")
+        _prof_has=$(echo "$_prof_has" | tr -d '[:space:]')
+        echo "Prometheus PROF metric: $([ "${_prof_has:-0}" -gt 0 ] 2>/dev/null && echo 'PRESENT' || echo 'NOT FOUND')"
     fi
     echo "=== END DCGM DIAGNOSTICS ==="
 fi


### PR DESCRIPTION
## Summary
DCGM pods running 8+ hours on customer cluster but Prometheus never scraped them. Root cause: `kubernetes_sd_configs` with `role: endpoints` silently fails on clusters where endpoint RBAC doesn't work as expected.

## Fix
- **globalvalues.yaml**: Replace `kubernetes_sd_configs` with `dns_sd_configs` for the `dcgm-gpu-metrics` scrape job. DNS resolution needs no RBAC — always works.
- **patching.sh**: After DCGM deploy, patch the Prometheus ConfigMap to replace old `kubernetes_sd_configs` with `dns_sd_configs`. Fixes existing clusters with old deployer images. Condition only fires when `kubernetes_sd_configs` is specifically in the dcgm block (not other jobs).
- **bash fix**: `grep -c` multiline output in PROF metric diagnostic.

## Validated
- dns_sd_configs tested on live test cluster — PROF metric scraped with fresh timestamps
- sed replacement tested on original kubernetes_sd_configs config — correct output
- Condition guard tested: no false positives when kubernetes_sd_configs exists in other jobs
- Already-patched ConfigMap: condition correctly skips

## Test plan
- [ ] 843 tests passing
- [ ] bash -n syntax valid
- [ ] sed replacement validated on live ConfigMap
- [ ] dns_sd_configs verified on live cluster with active DCGM scraping