### PR TITLE
fix(gpu): fix ConfigMap patch — sed indentation mismatch

### DIFF
--- a/src/patching.sh
+++ b/src/patching.sh
@@ -2387,22 +2387,27 @@ DCGM_EOF
         # Patch Prometheus ConfigMap: replace kubernetes_sd_configs DCGM job with dns_sd_configs.
         # Old deployer images have kubernetes_sd_configs which requires cluster-wide endpoint RBAC
         # and fails silently on some clusters. dns_sd_configs uses DNS (always works).
-        _prom_cm=$(kubectl get cm onelens-agent-prometheus-server -n onelens-agent -o jsonpath='{.data.prometheus\.yml}' 2>/dev/null || true)
-        _dcgm_block=$(echo "$_prom_cm" | sed -n '/job_name: dcgm-gpu-metrics/,/^    - job_name:\|^  serverFiles:/p' 2>/dev/null || true)
-        if echo "$_dcgm_block" | grep -q 'kubernetes_sd_configs' 2>/dev/null; then
+        _prom_cm=$(kubectl get cm onelens-agent-prometheus-server -n onelens-agent -o json 2>/dev/null | jq -r '.data["prometheus.yml"]' 2>/dev/null || true)
+        if echo "$_prom_cm" | awk '/job_name: dcgm-gpu-metrics/,0' 2>/dev/null | grep -q 'kubernetes_sd_configs' 2>/dev/null; then
             echo "Patching Prometheus scrape config: dcgm-gpu-metrics → dns_sd_configs"
-            _prom_cm_fixed=$(echo "$_prom_cm" | sed '/- job_name: dcgm-gpu-metrics/,/^    - job_name:\|^  serverFiles:/c\
-    - job_name: dcgm-gpu-metrics\
-      honor_labels: true\
-      scrape_interval: 30s\
-      scrape_timeout: 10s\
-      metrics_path: /metrics\
-      scheme: http\
-      dns_sd_configs:\
-        - names:\
-            - nvidia-dcgm-exporter.onelens-agent\
-          type: A\
-          port: 9400')
+            _prom_cm_fixed=$(echo "$_prom_cm" | python3 -c "
+import sys, re
+content = sys.stdin.read()
+new_job = '''- job_name: dcgm-gpu-metrics
+  honor_labels: true
+  scrape_interval: 30s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  dns_sd_configs:
+    - names:
+        - nvidia-dcgm-exporter.onelens-agent
+      type: A
+      port: 9400'''
+pattern = r'- job_name: dcgm-gpu-metrics.*?(?=\n- job_name:|\Z)'
+result = re.sub(pattern, new_job, content, flags=re.DOTALL)
+print(result)
+" 2>/dev/null)
             if [ -n "$_prom_cm_fixed" ]; then
                 echo "$_prom_cm_fixed" > /tmp/prom-config-patched.yml
                 kubectl create cm onelens-agent-prometheus-server -n onelens-agent \


### PR DESCRIPTION
## Summary
v2.1.75 ConfigMap patch never fired because sed patterns assumed 4-space indentation that didn't match the actual ConfigMap (0-space — extraScrapeConfigs is a literal block scalar).

## Fix
- Read ConfigMap via `jq` (not jsonpath)
- Check condition via `awk` (handles last-block-in-file case)
- Replace via `python3` regex (indentation-independent)

## Expected on customer cluster after patch
1. Patching logs: `Patching Prometheus scrape config: dcgm-gpu-metrics → dns_sd_configs`
2. Diagnostics: `Prometheus PROF metric: PRESENT`
3. Next agent run: `gpuUsageAverage` non-null

## Validated
Tested on live test cluster ConfigMap — condition matches, replacement produces correct output.

## Test plan
- [ ] bash -n syntax valid
- [ ] Condition + replacement tested on live ConfigMap with kubernetes_sd_configs
- [ ] 843 tests passing