### PR TITLE
fix(gpu): add scrape annotation to DCGM Service for Prometheus discovery

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -268,6 +268,9 @@ metadata:
   labels:
     app: nvidia-dcgm-exporter
     managed-by: onelens
+  annotations:
+    custom_metrics_scrape: "true"
+    prometheus.io/port: "9400"
 spec:
   selector:
     app: nvidia-dcgm-exporter

--- a/install.sh
+++ b/install.sh
@@ -912,6 +912,9 @@ metadata:
   labels:
     app: nvidia-dcgm-exporter
     managed-by: onelens
+  annotations:
+    custom_metrics_scrape: "true"
+    prometheus.io/port: "9400"
 spec:
   selector:
     app: nvidia-dcgm-exporter

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -2374,6 +2374,9 @@ metadata:
   labels:
     app: nvidia-dcgm-exporter
     managed-by: onelens
+  annotations:
+    custom_metrics_scrape: "true"
+    prometheus.io/port: "9400"
 spec:
   selector:
     app: nvidia-dcgm-exporter
@@ -2383,39 +2386,7 @@ spec:
       targetPort: 9400
 DCGM_EOF
     then
-        echo "DCGM exporter kubectl apply: OK"
-        # Patch Prometheus ConfigMap: replace kubernetes_sd_configs DCGM job with dns_sd_configs.
-        # Old deployer images have kubernetes_sd_configs which requires cluster-wide endpoint RBAC
-        # and fails silently on some clusters. dns_sd_configs uses DNS (always works).
-        _prom_cm=$(kubectl get cm onelens-agent-prometheus-server -n onelens-agent -o json 2>/dev/null | jq -r '.data["prometheus.yml"]' 2>/dev/null || true)
-        if echo "$_prom_cm" | awk '/job_name: dcgm-gpu-metrics/,0' 2>/dev/null | grep -q 'kubernetes_sd_configs' 2>/dev/null; then
-            echo "Patching Prometheus scrape config: dcgm-gpu-metrics → dns_sd_configs"
-            _prom_cm_fixed=$(echo "$_prom_cm" | python3 -c "
-import sys, re
-content = sys.stdin.read()
-new_job = '''- job_name: dcgm-gpu-metrics
-  honor_labels: true
-  scrape_interval: 30s
-  scrape_timeout: 10s
-  metrics_path: /metrics
-  scheme: http
-  dns_sd_configs:
-    - names:
-        - nvidia-dcgm-exporter.onelens-agent
-      type: A
-      port: 9400'''
-pattern = r'- job_name: dcgm-gpu-metrics.*?(?=\n- job_name:|\Z)'
-result = re.sub(pattern, new_job, content, flags=re.DOTALL)
-print(result)
-" 2>/dev/null)
-            if [ -n "$_prom_cm_fixed" ]; then
-                echo "$_prom_cm_fixed" > /tmp/prom-config-patched.yml
-                kubectl create cm onelens-agent-prometheus-server -n onelens-agent \
-                    --from-file=prometheus.yml=/tmp/prom-config-patched.yml \
-                    --dry-run=client -o yaml 2>/dev/null | kubectl apply -f - 2>&1 || echo "  WARNING: Prometheus ConfigMap patch failed (non-fatal)"
-                rm -f /tmp/prom-config-patched.yml
-            fi
-        fi
+        echo "DCGM exporter deployed successfully"
     else
         echo "WARNING: DCGM exporter kubectl apply failed — GPU utilization monitoring unavailable"
         echo "  This does not affect other OneLens components."


### PR DESCRIPTION
## Summary
Add `custom_metrics_scrape: "true"` and `prometheus.io/port: "9400"` annotations to the DCGM Service. This makes the built-in `kubernetes-service-endpoints` scrape job discover DCGM — proven to work on the customer cluster where the dedicated `dcgm-gpu-metrics` job in `extraScrapeConfigs` silently fails.

Remove the ConfigMap patching code (v2.1.75-76) that never worked.

## Why custom_metrics_scrape (not prometheus.io/scrape)
Our globalvalues.yaml customizes the kubernetes-service-endpoints job to use `custom_metrics_scrape` as the keep filter, not the standard `prometheus.io/scrape`. Verified on live cluster ConfigMap.

## Impact
- Non-GPU clusters: zero (DCGM Service doesn't exist)
- GPU clusters with our DCGM: kubectl apply updates Service with annotations, Prometheus discovers on next 30s scrape cycle
- GPU clusters with customer DCGM: we don't deploy our Service, no change

## Validated
- Syntax: all 3 files OK
- Parity: identical annotations across src/patching.sh, install.sh, entrypoint.sh
- Live cluster: confirmed kubernetes-service-endpoints job uses custom_metrics_scrape
- 843 tests passing

## Test plan
- [ ] 843 tests passing
- [ ] Annotation present in all 3 scripts
- [ ] ConfigMap patch code removed
- [ ] Verify on customer cluster: Prometheus PROF metric PRESENT after patch