### PR TITLE
fix(airgapped): serve globalvalues.yaml from GitHub Pages

### DIFF
--- a/.github/workflows/helm-package-release.yml
+++ b/.github/workflows/helm-package-release.yml
@@ -180,6 +180,12 @@ jobs:
           echo "Air-gapped scripts in gh-pages:"
           ls -la gh-pages-repo/scripts/airgapped/
 
+      - name: Copy versioned globalvalues.yaml to gh-pages
+        run: |
+          TAG_VERSION="${{ needs.validate-and-determine-version.outputs.tag_version }}"
+          cp globalvalues.yaml "gh-pages-repo/globalvalues-v${TAG_VERSION}.yaml"
+          echo "Published globalvalues-v${TAG_VERSION}.yaml to gh-pages"
+
       - name: Update Helm repository index
         run: |
           cd gh-pages-repo

--- a/docs/airgapped-deployment-guide.md
+++ b/docs/airgapped-deployment-guide.md
@@ -79,11 +79,12 @@ Deploy OneLens on Kubernetes clusters that have restricted or no internet access
 | URL | Used in | Purpose |
 |-----|---------|---------|
 | `https://api-in.onelens.cloud` | Pre-check | Validate connectivity to OneLens API |
-| `https://astuto-ai.github.io` | Migration | Download Helm charts and version config from the OneLens public GitHub repository |
+| `https://astuto-ai.github.io` | Migration | Download Helm charts, migration script, and version config from the OneLens public GitHub repository |
 | `https://public.ecr.aws` | Migration | Pull `onelens-agent` and `onelens-deployer` container images |
 | `https://quay.io` | Migration | Pull `prometheus`, `config-reloader`, `pushgateway`, `kube-rbac-proxy` images |
 | `https://registry.k8s.io` | Migration | Pull `kube-state-metrics` image |
 | `https://ghcr.io` | Migration | Pull `opencost` image |
+| `https://nvcr.io` | Migration | Pull `dcgm-exporter` image (GPU monitoring — only needed for GPU clusters) |
 
 **Cluster nodes** (air-gapped — no general internet access):
 
@@ -170,6 +171,14 @@ The script tests:
 ## Step 2: Mirror Images and Set Up Cluster Resources
 
 This step runs **once per OneLens version** on a machine with internet access AND `kubectl` access to the target cluster.
+
+First, download the migration script:
+
+```bash
+curl -fsSL https://astuto-ai.github.io/onelens-installation-scripts/scripts/airgapped/airgapped_migrate_images.sh -o airgapped_migrate_images.sh
+```
+
+Then run it:
 
 ```bash
 bash airgapped_migrate_images.sh --registry <your-registry-url>/<prefix>
@@ -265,7 +274,10 @@ All pods should be in `Running` state:
 
 ### Step 1: Re-run the migration script (once per version, on your setup machine)
 
+Download the latest migration script and run it:
+
 ```bash
+curl -fsSL https://astuto-ai.github.io/onelens-installation-scripts/scripts/airgapped/airgapped_migrate_images.sh -o airgapped_migrate_images.sh
 bash airgapped_migrate_images.sh --registry <your-registry-url>
 ```
 
@@ -370,6 +382,7 @@ The following images are mirrored by `airgapped_migrate_images.sh`. The list is 
 | `kube-state-metrics` | `registry.k8s.io` | Kubernetes state metrics |
 | `pushgateway` | `quay.io` | Prometheus push gateway |
 | `kube-rbac-proxy` | `quay.io` | RBAC proxy for kube-state-metrics |
+| `dcgm-exporter` | `nvcr.io` | NVIDIA GPU metrics (only for GPU clusters) |
 
 > Exact tags depend on the version you deploy. The migration script handles this automatically.
 

--- a/scripts/airgapped/airgapped_migrate_images.sh
+++ b/scripts/airgapped/airgapped_migrate_images.sh
@@ -106,10 +106,8 @@ echo "Fetching image list for version $VERSION..."
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# Download globalvalues.yaml from the tagged release on GitHub.
-# This is more reliable than helm show values — the chart's packaged values have different
-# YAML structure (nested sub-chart keys) that makes grep-based parsing fragile.
-_GV_URL="https://raw.githubusercontent.com/astuto-ai/onelens-installation-scripts/v${VERSION}/globalvalues.yaml"
+# Download globalvalues.yaml from GitHub Pages (published per-version by the release CI).
+_GV_URL="https://astuto-ai.github.io/onelens-installation-scripts/globalvalues-v${VERSION}.yaml"
 curl -fsSL "$_GV_URL" -o "$TMPDIR/values.yaml"
 
 if [ ! -s "$TMPDIR/values.yaml" ]; then

--- a/tests/test-airgapped.sh
+++ b/tests/test-airgapped.sh
@@ -144,10 +144,10 @@ assert_gt "$check_api" "0" "accessibility check tests OneLens API endpoint"
 assert_gt "$check_upload" "0" "accessibility check tests upload gateway endpoint"
 
 # ---------------------------------------------------------------------------
-# Test 19: Migration script fetches globalvalues.yaml from raw GitHub
+# Test 19: Migration script fetches globalvalues.yaml from GitHub Pages
 # ---------------------------------------------------------------------------
-migrate_dynamic=$(grep -c 'raw.githubusercontent.com' "$MIGRATE" || true)
-assert_gt "$migrate_dynamic" "0" "migration script fetches globalvalues.yaml from raw GitHub"
+migrate_dynamic=$(grep -c 'astuto-ai.github.io.*globalvalues' "$MIGRATE" || true)
+assert_gt "$migrate_dynamic" "0" "migration script fetches globalvalues.yaml from GitHub Pages"
 
 # ---------------------------------------------------------------------------
 # Test 20: patching.sh helm upgrade line uses $CHART_SOURCE (not hardcoded)


### PR DESCRIPTION
## Summary
- CI now publishes versioned `globalvalues-v${VERSION}.yaml` to gh-pages on each release
- Migration script fetches from `astuto-ai.github.io` instead of `raw.githubusercontent.com` — customers only need one GitHub domain whitelisted
- Docs: added missing `curl -o` download step for migration script, added `nvcr.io` to network table, added `dcgm-exporter` to images reference

## Test plan
- [x] All 41 airgapped tests pass (including updated Test 19)
- [x] CI workflow YAML validated
- [x] New GitHub Pages URL pattern confirmed (404 expected pre-release, will be created by CI on next tag)
- [x] Migration script download URL verified reachable on gh-pages
- [ ] Full E2E: next release will publish `globalvalues-v${VERSION}.yaml` to gh-pages