### PR TITLE
feat: add network costs support to install/patching scripts

### DIFF
--- a/charts/onelensdeployer/values.yaml
+++ b/charts/onelensdeployer/values.yaml
@@ -128,6 +128,13 @@ rbac:
         resources:
           - storageclasses
         verbs: ["get", "list", "watch"]
+      # Leader election for network costs DaemonSet (coordination API)
+      # Required by RBAC escalation protection: deployer must hold these
+      # permissions to grant them to the agent's workload-reader ClusterRole.
+      - apiGroups: ["coordination.k8s.io"]
+        resources:
+          - leases
+        verbs: ["get", "list", "watch", "create", "update"]
       # Non-resource URL permissions for Prometheus metrics scraping
       - nonResourceURLs:
           - /metrics
@@ -188,6 +195,7 @@ job:
   labels: {}
   env:
     deployment_type: job
+    NETWORK_COSTS_ENABLED: ""
   resources:
     requests:
       cpu: 200m
@@ -224,6 +232,7 @@ cronjob:
   labels: {}
   env:
     deployment_type: cronjob
+    NETWORK_COSTS_ENABLED: ""
   resources:
     requests:
       cpu: 200m

--- a/charts/onelensdeployer/values.yaml
+++ b/charts/onelensdeployer/values.yaml
@@ -130,11 +130,11 @@ rbac:
         verbs: ["get", "list", "watch"]
       # Leader election for network costs DaemonSet (coordination API)
       # Required by RBAC escalation protection: deployer must hold these
-      # permissions to grant them to the agent's workload-reader ClusterRole.
+      # permissions to grant them to the agent's network-costs-leader-election Role.
       - apiGroups: ["coordination.k8s.io"]
         resources:
           - leases
-        verbs: ["get", "list", "watch", "create", "update"]
+        verbs: ["get", "list", "watch", "create", "update", "patch"]
       # Non-resource URL permissions for Prometheus metrics scraping
       - nonResourceURLs:
           - /metrics

--- a/globalvalues.yaml
+++ b/globalvalues.yaml
@@ -304,6 +304,17 @@ prometheus:
             - nvidia-dcgm-exporter.onelens-agent
           type: A
           port: 9400
+    - job_name: network-costs
+      honor_labels: true
+      scrape_interval: 1m
+      scrape_timeout: 10s
+      metrics_path: /metrics
+      scheme: http
+      dns_sd_configs:
+        - names:
+            - opencost-network-costs.onelens-agent
+          type: A
+          port: 3001
   serverFiles:
     alerting_rules.yml: {}
     alerts: {}

--- a/install.sh
+++ b/install.sh
@@ -567,6 +567,9 @@ export AZURE_DISK_ENCRYPTION_ENABLED="${AZURE_DISK_ENCRYPTION_ENABLED:=false}"
 export AZURE_DISK_ENCRYPTION_SET_ID="${AZURE_DISK_ENCRYPTION_SET_ID:=}"
 export AZURE_DISK_CACHING_MODE="${AZURE_DISK_CACHING_MODE:=ReadOnly}"
 
+## Network cost attribution (opt-in)
+export NETWORK_COSTS_ENABLED="${NETWORK_COSTS_ENABLED:=}"
+
 FILE="globalvalues.yaml"
 
 echo "using $FILE"
@@ -674,6 +677,23 @@ if [ "$CLOUD_PROVIDER" = "AWS" ]; then
     CMD+=" --set onelens-agent.storageClass.volumeType=\"$STORAGE_CLASS_VOLUME_TYPE\""
 elif [ "$CLOUD_PROVIDER" = "AZURE" ]; then
     CMD+=" --set onelens-agent.storageClass.azure.skuName=\"$STORAGE_CLASS_SKU\""
+fi
+
+# Network costs (opt-in)
+if [ "${NETWORK_COSTS_ENABLED:-}" = "true" ]; then
+    echo "Network costs: enabled (NETWORK_COSTS_ENABLED=true)"
+    CMD+=" --set onelens-agent.networkCosts.enabled=true"
+    if [ "$CLOUD_PROVIDER" = "AWS" ]; then
+        CMD+=" --set onelens-agent.networkCosts.cloudProvider.aws=true"
+        echo "Network costs: cloudProvider=aws"
+    elif [ "$CLOUD_PROVIDER" = "AZURE" ]; then
+        CMD+=" --set onelens-agent.networkCosts.cloudProvider.azure=true"
+        echo "Network costs: cloudProvider=azure"
+    fi
+    if [ -n "$REGISTRY_URL" ]; then
+        CMD+=" --set onelens-agent.networkCosts.image.registry=$REGISTRY_URL"
+        CMD+=" --set onelens-agent.networkCosts.image.repository=onelens-network-costs"
+    fi
 fi
 
 # Multi-AZ storage overrides (EFS for AWS, Azure Files for Azure)

--- a/scripts/airgapped/airgapped_migrate_images.sh
+++ b/scripts/airgapped/airgapped_migrate_images.sh
@@ -226,6 +226,16 @@ IMAGES="${IMAGES}
 ${_repo}:${_tag} dcgm-exporter:${_tag}"
 echo "  dcgm-exporter: ${_repo}:${_tag}"
 
+# onelens-network-costs (network cost attribution — only deployed on enabled clusters)
+_repo="public.ecr.aws/w7k6q5m9/onelens-network-costs"
+_tag=$(grep -A5 'networkCosts:' "$_V" | grep -A3 'image:' | grep 'tag:' | head -1 | awk '{print $2}' | tr -d '"' || true)
+if [ -z "$_tag" ]; then
+    _tag="0.1.1"
+fi
+IMAGES="${IMAGES}
+${_repo}:${_tag} onelens-network-costs:${_tag}"
+echo "  onelens-network-costs: ${_repo}:${_tag}"
+
 # --- Mirror images ---
 echo ""
 echo "=== Mirroring images ==="

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -468,6 +468,12 @@ if [[ -n "$CURRENT_VALUES" ]] && command -v jq &>/dev/null; then
   # Read gpu.enabled WITHOUT -a flag — only user-supplied values, not chart defaults.
   # The chart default is "false" which would be mistaken for a customer override with -a.
   GPU_ENABLED_OVERRIDE=$(helm get values onelens-agent -n onelens-agent -o json 2>/dev/null | jq -r '.["onelens-agent"].gpu.enabled // empty' 2>/dev/null || true)
+  # Read networkCosts values WITHOUT -a flag — only user-supplied values, not chart defaults.
+  _nc_vals=$(helm get values onelens-agent -n onelens-agent -o json 2>/dev/null || true)
+  NC_ENABLED_OVERRIDE=$(echo "$_nc_vals" | jq -r '.["onelens-agent"].networkCosts.enabled // empty' 2>/dev/null || true)
+  NC_CLOUD_AWS=$(echo "$_nc_vals" | jq -r '.["onelens-agent"].networkCosts.cloudProvider.aws // empty' 2>/dev/null || true)
+  NC_CLOUD_GCP=$(echo "$_nc_vals" | jq -r '.["onelens-agent"].networkCosts.cloudProvider.gcp // empty' 2>/dev/null || true)
+  NC_CLOUD_AZURE=$(echo "$_nc_vals" | jq -r '.["onelens-agent"].networkCosts.cloudProvider.azure // empty' 2>/dev/null || true)
   # Note: Can't use _get for booleans — jq's `false // empty` returns empty since false is falsy
   PVC_ENABLED=$(echo "$CURRENT_VALUES" | jq -r '.prometheus.server.persistentVolume.enabled // "true"')
 
@@ -535,6 +541,10 @@ else
   DEFAULT_CLUSTER_ID=""
   REGISTRY_URL=""
   GPU_ENABLED_OVERRIDE=""
+  NC_ENABLED_OVERRIDE=""
+  NC_CLOUD_AWS=""
+  NC_CLOUD_GCP=""
+  NC_CLOUD_AZURE=""
   PVC_ENABLED="true"
   SC_PROVISIONER=""
   CUSTOMER_VALUES_FILE=""
@@ -1021,6 +1031,46 @@ elif [ "$GPU_NODE_COUNT" -gt 0 ]; then
     else
         GPU_ENABLED="true"
         echo "GPU helm value: gpu.enabled=true (deploying OneLens DCGM exporter)"
+    fi
+fi
+
+# --- Network Costs: resolve enabled + cloud provider for helm upgrade ---
+# Unlike GPU (kubectl apply, decoupled from helm), network costs uses helm chart
+# templates — so we must pass --set flags to helm upgrade.
+NC_ENABLED="false"
+if [ "$NC_ENABLED_OVERRIDE" = "true" ]; then
+    NC_ENABLED="true"
+    echo "Network costs: enabled=true (from existing helm release)"
+elif [ "${NETWORK_COSTS_ENABLED:-}" = "true" ]; then
+    NC_ENABLED="true"
+    echo "Network costs: enabled=true (from deployer env var)"
+else
+    echo "Network costs: disabled"
+fi
+
+NC_CLOUD_FLAG=""
+if [ "$NC_ENABLED" = "true" ]; then
+    if [ "$NC_CLOUD_AWS" = "true" ]; then
+        NC_CLOUD_FLAG="aws"
+        echo "Network costs: cloudProvider=aws (from existing helm values)"
+    elif [ "$NC_CLOUD_GCP" = "true" ]; then
+        NC_CLOUD_FLAG="gcp"
+        echo "Network costs: cloudProvider=gcp (from existing helm values)"
+    elif [ "$NC_CLOUD_AZURE" = "true" ]; then
+        NC_CLOUD_FLAG="azure"
+        echo "Network costs: cloudProvider=azure (from existing helm values)"
+    elif echo "$SC_PROVISIONER" | grep -q "ebs.csi.aws.com"; then
+        NC_CLOUD_FLAG="aws"
+        echo "Network costs: cloudProvider=aws (auto-detected from SC provisioner)"
+    elif echo "$SC_PROVISIONER" | grep -q "pd.csi.storage.gke.io"; then
+        NC_CLOUD_FLAG="gcp"
+        echo "Network costs: cloudProvider=gcp (auto-detected from SC provisioner)"
+    elif echo "$SC_PROVISIONER" | grep -q "disk.csi.azure.com"; then
+        NC_CLOUD_FLAG="azure"
+        echo "Network costs: cloudProvider=azure (auto-detected from SC provisioner)"
+    else
+        NC_CLOUD_FLAG="aws"
+        echo "Network costs: cloudProvider=aws (default — unknown provisioner: ${SC_PROVISIONER:-empty})"
     fi
 fi
 
@@ -1689,6 +1739,17 @@ if [ -n "$REGISTRY_URL" ]; then
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.registry=$REGISTRY_URL \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.repository=kube-rbac-proxy \
       --set onelens-agent.env.REGISTRY_URL=$REGISTRY_URL"
+fi
+
+# Network costs settings (opt-in, preserved from existing release)
+HELM_CMD="$HELM_CMD --set onelens-agent.networkCosts.enabled=$NC_ENABLED"
+if [ "$NC_ENABLED" = "true" ] && [ -n "$NC_CLOUD_FLAG" ]; then
+    HELM_CMD="$HELM_CMD --set onelens-agent.networkCosts.cloudProvider.${NC_CLOUD_FLAG}=true"
+fi
+if [ -n "$REGISTRY_URL" ] && [ "$NC_ENABLED" = "true" ]; then
+    HELM_CMD="$HELM_CMD \
+      --set onelens-agent.networkCosts.image.registry=$REGISTRY_URL \
+      --set onelens-agent.networkCosts.image.repository=onelens-network-costs"
 fi
 
 # Force-delete pods stuck in Terminating for >10 min before helm upgrade.

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -465,15 +465,14 @@ if [[ -n "$CURRENT_VALUES" ]] && command -v jq &>/dev/null; then
   REGISTRATION_ID=$(_get '.["onelens-agent"].secrets.REGISTRATION_ID')
   DEFAULT_CLUSTER_ID=$(_get '.["prometheus-opencost-exporter"].opencost.exporter.defaultClusterId')
   REGISTRY_URL=$(_get '.["onelens-agent"].env.REGISTRY_URL')
-  # Read gpu.enabled WITHOUT -a flag — only user-supplied values, not chart defaults.
-  # The chart default is "false" which would be mistaken for a customer override with -a.
-  GPU_ENABLED_OVERRIDE=$(helm get values onelens-agent -n onelens-agent -o json 2>/dev/null | jq -r '.["onelens-agent"].gpu.enabled // empty' 2>/dev/null || true)
-  # Read networkCosts values WITHOUT -a flag — only user-supplied values, not chart defaults.
-  _nc_vals=$(helm get values onelens-agent -n onelens-agent -o json 2>/dev/null || true)
-  NC_ENABLED_OVERRIDE=$(echo "$_nc_vals" | jq -r '.["onelens-agent"].networkCosts.enabled // empty' 2>/dev/null || true)
-  NC_CLOUD_AWS=$(echo "$_nc_vals" | jq -r '.["onelens-agent"].networkCosts.cloudProvider.aws // empty' 2>/dev/null || true)
-  NC_CLOUD_GCP=$(echo "$_nc_vals" | jq -r '.["onelens-agent"].networkCosts.cloudProvider.gcp // empty' 2>/dev/null || true)
-  NC_CLOUD_AZURE=$(echo "$_nc_vals" | jq -r '.["onelens-agent"].networkCosts.cloudProvider.azure // empty' 2>/dev/null || true)
+  # Read user-supplied values WITHOUT -a flag — chart defaults like "false" would
+  # be mistaken for customer overrides with -a. Single call for GPU + NC fields.
+  _user_vals=$(helm get values onelens-agent -n onelens-agent -o json 2>/dev/null || true)
+  GPU_ENABLED_OVERRIDE=$(echo "$_user_vals" | jq -r '.["onelens-agent"].gpu.enabled // empty' 2>/dev/null || true)
+  NC_ENABLED_OVERRIDE=$(echo "$_user_vals" | jq -r '.["onelens-agent"].networkCosts.enabled // empty' 2>/dev/null || true)
+  NC_CLOUD_AWS=$(echo "$_user_vals" | jq -r '.["onelens-agent"].networkCosts.cloudProvider.aws // empty' 2>/dev/null || true)
+  NC_CLOUD_GCP=$(echo "$_user_vals" | jq -r '.["onelens-agent"].networkCosts.cloudProvider.gcp // empty' 2>/dev/null || true)
+  NC_CLOUD_AZURE=$(echo "$_user_vals" | jq -r '.["onelens-agent"].networkCosts.cloudProvider.azure // empty' 2>/dev/null || true)
   # Note: Can't use _get for booleans — jq's `false // empty` returns empty since false is falsy
   PVC_ENABLED=$(echo "$CURRENT_VALUES" | jq -r '.prometheus.server.persistentVolume.enabled // "true"')
 

--- a/tests/test-airgapped.sh
+++ b/tests/test-airgapped.sh
@@ -253,5 +253,19 @@ done
 bastion_ghpages=$(grep -c 'astuto-ai.github.io' "$BASTION" || true)
 assert_gt "$bastion_ghpages" "0" "bastion precheck tests GitHub Pages access"
 
+# ---------------------------------------------------------------------------
+# Test 34: Migration script includes onelens-network-costs image
+# ---------------------------------------------------------------------------
+migrate_nc=$(grep -c 'onelens-network-costs' "$MIGRATE" || true)
+assert_gt "$migrate_nc" "0" "migration script includes onelens-network-costs image"
+
+# ---------------------------------------------------------------------------
+# Test 35: Both scripts have network-costs air-gapped image overrides
+# ---------------------------------------------------------------------------
+install_nc_override=$(grep -c 'networkCosts.image.registry=\$REGISTRY_URL' "$ROOT/install.sh" || true)
+patching_nc_override=$(grep -c 'networkCosts.image.registry=\$REGISTRY_URL' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_nc_override" "0" "install.sh has network-costs air-gapped image override"
+assert_gt "$patching_nc_override" "0" "patching.sh has network-costs air-gapped image override"
+
 test_summary
 exit $?

--- a/tests/test-helm-render.sh
+++ b/tests/test-helm-render.sh
@@ -285,6 +285,53 @@ else
 fi
 
 ###############################################################################
+# globalvalues.yaml validation
+###############################################################################
+
+GV="$ROOT/globalvalues.yaml"
+
+# globalvalues.yaml must be valid YAML
+gv_yaml_check=$(python3 -c "import yaml; yaml.safe_load(open('$GV'))" 2>&1); gv_rc=$?
+if [ $gv_rc -eq 0 ]; then
+    assert_eq "0" "0" "globalvalues.yaml is valid YAML"
+else
+    assert_eq "$gv_rc" "0" "globalvalues.yaml is valid YAML: $gv_yaml_check"
+fi
+
+# extraScrapeConfigs contains network-costs job
+gv_nc_job=$(grep -c 'job_name: network-costs' "$GV" || true)
+assert_gt "$gv_nc_job" "0" "globalvalues.yaml has network-costs scrape job"
+
+# network-costs job targets port 3001
+gv_nc_port=$(grep -A12 'job_name: network-costs' "$GV" | grep -c '3001' || true)
+assert_gt "$gv_nc_port" "0" "network-costs scrape job targets port 3001"
+
+# network-costs job uses correct service name
+gv_nc_svc=$(grep -A8 'job_name: network-costs' "$GV" | grep -c 'opencost-network-costs.onelens-agent' || true)
+assert_gt "$gv_nc_svc" "0" "network-costs scrape job targets opencost-network-costs.onelens-agent"
+
+###############################################################################
+# Deployer chart validation
+###############################################################################
+
+DV="$ROOT/charts/onelensdeployer/values.yaml"
+
+# Deployer ClusterRole has coordination.k8s.io/leases
+dv_leases=$(grep -c 'coordination.k8s.io' "$DV" || true)
+assert_gt "$dv_leases" "0" "deployer ClusterRole includes coordination.k8s.io"
+
+dv_leases_resource=$(grep -A2 'coordination.k8s.io' "$DV" | grep -c 'leases' || true)
+assert_gt "$dv_leases_resource" "0" "deployer ClusterRole has leases resource"
+
+# Deployer job.env has NETWORK_COSTS_ENABLED
+dv_job_nc=$(sed -n '/^job:/,/^cronjob:/p' "$DV" | grep -c 'NETWORK_COSTS_ENABLED' || true)
+assert_gt "$dv_job_nc" "0" "deployer job.env has NETWORK_COSTS_ENABLED"
+
+# Deployer cronjob.env has NETWORK_COSTS_ENABLED
+dv_cron_nc=$(sed -n '/^cronjob:/,/^$/p' "$DV" | grep -c 'NETWORK_COSTS_ENABLED' || true)
+assert_gt "$dv_cron_nc" "0" "deployer cronjob.env has NETWORK_COSTS_ENABLED"
+
+###############################################################################
 # Summary
 ###############################################################################
 test_summary

--- a/tests/test-parity.sh
+++ b/tests/test-parity.sh
@@ -442,5 +442,29 @@ patching_prefix=$(grep -c 'startswith("nvidia.com/gpu")' "$ROOT/src/patching.sh"
 assert_gt "$install_prefix" "0" "install.sh uses prefix search for nvidia.com/gpu labels"
 assert_gt "$patching_prefix" "0" "patching.sh uses prefix search for nvidia.com/gpu labels"
 
+# ---------------------------------------------------------------------------
+# Test 54: Both scripts pass networkCosts.enabled to helm
+# ---------------------------------------------------------------------------
+install_nc_enabled=$(grep -c 'networkCosts.enabled' "$ROOT/install.sh" || true)
+patching_nc_enabled=$(grep -c 'networkCosts.enabled' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_nc_enabled" "0" "install.sh passes networkCosts.enabled to helm"
+assert_gt "$patching_nc_enabled" "0" "patching.sh passes networkCosts.enabled to helm"
+
+# ---------------------------------------------------------------------------
+# Test 55: Both scripts pass networkCosts.cloudProvider to helm
+# ---------------------------------------------------------------------------
+install_nc_cloud=$(grep -c 'networkCosts.cloudProvider' "$ROOT/install.sh" || true)
+patching_nc_cloud=$(grep -c 'networkCosts.cloudProvider' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_nc_cloud" "0" "install.sh passes networkCosts.cloudProvider to helm"
+assert_gt "$patching_nc_cloud" "0" "patching.sh passes networkCosts.cloudProvider to helm"
+
+# ---------------------------------------------------------------------------
+# Test 56: Both scripts have air-gapped network-costs image overrides
+# ---------------------------------------------------------------------------
+install_nc_airgap=$(grep -c 'networkCosts.image.registry' "$ROOT/install.sh" || true)
+patching_nc_airgap=$(grep -c 'networkCosts.image.registry' "$ROOT/src/patching.sh" || true)
+assert_gt "$install_nc_airgap" "0" "install.sh has air-gapped network-costs image override"
+assert_gt "$patching_nc_airgap" "0" "patching.sh has air-gapped network-costs image override"
+
 test_summary
 exit $?


### PR DESCRIPTION
## Summary
- Integrate network costs DaemonSet support into deployer, install, and patching scripts
- Add Prometheus scrape config for network-costs service (port 3001)
- Auto-detect cloud provider from StorageClass provisioner in patching.sh
- Add air-gapped support for onelens-network-costs image

## Changes
- **charts/onelensdeployer/values.yaml** — coordination.k8s.io/leases RBAC, NETWORK_COSTS_ENABLED env var
- **globalvalues.yaml** — network-costs Prometheus scrape job via dns_sd_configs
- **src/patching.sh** — NC value preservation from helm release, cloud auto-detect from SC provisioner, helm --set flags
- **install.sh** — NETWORK_COSTS_ENABLED env var handling, cloud provider mapping, air-gapped override
- **scripts/airgapped/airgapped_migrate_images.sh** — onelens-network-costs image
- **tests/** — parity, air-gapped, and helm-render test coverage

## Safety
- networkCosts defaults to disabled — no impact on existing clusters
- Helm v3 silently accepts --set for unknown keys on old chart versions
- All new code is behind NC_ENABLED=true conditionals
- Bash 3.2 compatible, no associative arrays

## Test plan
- [ ] All 630+ tests passing locally
- [ ] Deploy with NETWORK_COSTS_ENABLED=true on test EKS cluster
- [ ] Verify patching.sh preserves NC values across helm upgrades
- [ ] Verify cloud auto-detection from SC provisioner
- [ ] Verify air-gapped image mirroring includes network-costs