### PR TITLE
feat(opencost): add Prometheus 3.x compatibility env vars

### DIFF
--- a/globalvalues.yaml
+++ b/globalvalues.yaml
@@ -851,7 +851,9 @@ prometheus-opencost-exporter:
         access_key_id: ""
       extraVolumeMounts: []
       env: []
-      extraEnv: {}
+      extraEnv:
+        PROMETHEUS_QUERY_RESOLUTION_SECONDS: "60"
+        PROM_CLUSTER_ID_LABEL: "__disabled__"
     customPricing:
       enabled: false
       configmapName: custom-pricing-model

--- a/tests/test-build.sh
+++ b/tests/test-build.sh
@@ -421,5 +421,21 @@ else
     echo "  SKIP: onelens-agent repo not adjacent — skipping chart template tests"
 fi
 
+# ---------------------------------------------------------------------------
+# OpenCost Prometheus 3.x compatibility env vars in globalvalues.yaml
+# ---------------------------------------------------------------------------
+
+gv_resolution=$(grep 'PROMETHEUS_QUERY_RESOLUTION_SECONDS' "$ROOT/globalvalues.yaml" | grep -v '#' | head -1)
+assert_ne "$gv_resolution" "" "globalvalues.yaml has PROMETHEUS_QUERY_RESOLUTION_SECONDS in OpenCost extraEnv"
+
+gv_resolution_val=$(echo "$gv_resolution" | awk -F'"' '{print $2}')
+assert_eq "$gv_resolution_val" "60" "PROMETHEUS_QUERY_RESOLUTION_SECONDS is 60"
+
+gv_cluster_label=$(grep 'PROM_CLUSTER_ID_LABEL' "$ROOT/globalvalues.yaml" | grep -v '#' | head -1)
+assert_ne "$gv_cluster_label" "" "globalvalues.yaml has PROM_CLUSTER_ID_LABEL in OpenCost extraEnv"
+
+gv_cluster_label_val=$(echo "$gv_cluster_label" | awk -F'"' '{print $2}')
+assert_eq "$gv_cluster_label_val" "__disabled__" "PROM_CLUSTER_ID_LABEL is __disabled__"
+
 test_summary
 exit $?


### PR DESCRIPTION
## Summary
- Adds `PROMETHEUS_QUERY_RESOLUTION_SECONDS=60` and `PROM_CLUSTER_ID_LABEL=__disabled__` to `globalvalues.yaml` under `opencost.exporter.extraEnv`
- `PROMETHEUS_QUERY_RESOLUTION_SECONDS=60`: Fixes subquery resolution mismatch where `increase(metric[2m:5m])` returns empty when range < step in Prometheus 3.x
- `PROM_CLUSTER_ID_LABEL=__disabled__`: Bypasses OpenCost's default `cluster_id` label grouping which doesn't exist in our metrics
- Previously set ephemerally via `kubectl set env` and wiped on every helm upgrade — now permanent in chart values
- Added 4 test assertions in `test-build.sh` validating both env vars

## Test plan
- [x] All 879 tests passing (17 suites, 0 failures)
- [x] Helm template renders both env vars correctly in OpenCost deployment
- [x] No conflicting `--set` flags in install.sh or patching.sh
- [x] Verified on test EKS cluster — env vars already active via kubectl, chart change makes them durable