### PR TITLE
fix: resolve container name in _detect_pod_failure and remediation

### DIFF
--- a/src/patching.sh
+++ b/src/patching.sh
@@ -2138,17 +2138,35 @@ _get_pod_failure_reason() {
 
 _remediate_oomkilled_pod() {
     local pod_name="$1"
-    local component="$2"
+    local component="$2"   # deployment name, e.g. onelens-agent-prometheus-server
     local current_memory
 
     echo ""
     echo "🔧 Attempting remediation: OOMKilled pod $pod_name"
 
+    # Resolve container name from pod spec — sidecar injectors may insert
+    # containers, so we cannot assume containers[0] is the app container.
+    # The component arg is the deployment name (e.g. onelens-agent-prometheus-server)
+    # but the container name may differ (e.g. prometheus-server). Try the deployment
+    # name first, then strip the "onelens-agent-" prefix as a fallback.
+    local container_name
+    container_name=$(kubectl get pod "$pod_name" -n onelens-agent \
+        -o jsonpath="{.spec.containers[?(@.name==\"$component\")].name}" 2>/dev/null || true)
+    if [ -z "$container_name" ]; then
+        local short_name="${component#onelens-agent-}"
+        container_name=$(kubectl get pod "$pod_name" -n onelens-agent \
+            -o jsonpath="{.spec.containers[?(@.name==\"$short_name\")].name}" 2>/dev/null || true)
+    fi
+    if [ -z "$container_name" ]; then
+        echo "⚠️  Cannot determine container name for $pod_name"
+        return 1
+    fi
+
     # Get current memory limit — read by container name to avoid picking up a
     # sidecar at containers[0]. A wrong read would feed into kubectl set resources
     # below and silently mis-size the deployment.
     current_memory=$(kubectl get pod "$pod_name" -n onelens-agent \
-        -o jsonpath="{.spec.containers[?(@.name==\"$component\")].resources.limits.memory}" 2>/dev/null)
+        -o jsonpath="{.spec.containers[?(@.name==\"$container_name\")].resources.limits.memory}" 2>/dev/null)
 
     if [ -z "$current_memory" ]; then
         echo "⚠️  Cannot determine current memory limit for $pod_name"
@@ -2169,8 +2187,10 @@ _remediate_oomkilled_pod() {
 
     echo "  Current memory: $current_memory → Increasing to ${new_memory_mi}Mi (1.5x)"
 
-    # Update deployment resource limit
+    # Update deployment resource limit — target specific container to avoid
+    # silently mis-sizing sidecar containers.
     if kubectl set resources deployment "$component" -n onelens-agent \
+        -c "$container_name" \
         --limits=memory="${new_memory_mi}Mi" 2>/dev/null; then
 
         echo "  ✅ Memory limit increased to ${new_memory_mi}Mi"
@@ -2233,6 +2253,7 @@ _remediate_cpu_starved_pod() {
 
     # Update deployment resource limits and requests
     if kubectl set resources deployment "$deploy_name" -n onelens-agent \
+        -c "$container_name" \
         --limits=cpu="$new_cpu" --requests=cpu="$new_cpu" 2>/dev/null; then
 
         echo "  ✅ CPU restored to $new_cpu"

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -1915,20 +1915,26 @@ $(kubectl get pods -n onelens-agent --no-headers 2>/dev/null \
 
         pod_status=$(kubectl get pod "$pod_name" -n onelens-agent \
             -o jsonpath='{.status.phase}' 2>/dev/null || true)
-        # Read by container name = component — sidecar injectors (Dynatrace, Istio)
-        # may insert containers at index 0. Fall back to $component if name-selector
-        # returns empty (chart default: container name matches component name).
+        # Resolve container name — sidecar injectors (Dynatrace, Istio) may insert
+        # containers, so we match by name. Try the short component name first (chart
+        # default), then the full deployment name (onelens-agent-<component>).
         container_name=$(kubectl get pod "$pod_name" -n onelens-agent \
             -o jsonpath="{.spec.containers[?(@.name==\"$component\")].name}" 2>/dev/null || true)
+        if [ -z "$container_name" ]; then
+            local deploy_name
+            deploy_name=$(echo "$pod_name" | sed 's/-[a-z0-9]*-[a-z0-9]*$//')
+            container_name=$(kubectl get pod "$pod_name" -n onelens-agent \
+                -o jsonpath="{.spec.containers[?(@.name==\"$deploy_name\")].name}" 2>/dev/null || true)
+        fi
         : "${container_name:=$component}"
         restart_count=$(kubectl get pod "$pod_name" -n onelens-agent \
-            -o jsonpath="{.status.containerStatuses[?(@.name==\"$component\")].restartCount}" 2>/dev/null || true)
+            -o jsonpath="{.status.containerStatuses[?(@.name==\"$container_name\")].restartCount}" 2>/dev/null || true)
         : "${restart_count:=0}"
         term_reason=$(kubectl get pod "$pod_name" -n onelens-agent \
-            -o jsonpath="{.status.containerStatuses[?(@.name==\"$component\")].state.terminated.reason}" 2>/dev/null || true)
+            -o jsonpath="{.status.containerStatuses[?(@.name==\"$container_name\")].state.terminated.reason}" 2>/dev/null || true)
         if [ -z "$term_reason" ]; then
             term_reason=$(kubectl get pod "$pod_name" -n onelens-agent \
-                -o jsonpath="{.status.containerStatuses[?(@.name==\"$component\")].lastState.terminated.reason}" 2>/dev/null || true)
+                -o jsonpath="{.status.containerStatuses[?(@.name==\"$container_name\")].lastState.terminated.reason}" 2>/dev/null || true)
         fi
 
         # Skip pods that are Running with low restarts — but only if fully Ready.

--- a/tests/test-build.sh
+++ b/tests/test-build.sh
@@ -323,10 +323,10 @@ updater_oom_name_selector=$(grep -c 'containerStatuses\[?(@.name=="onelensupdate
 assert_ge "$updater_oom_name_selector" "1" "src/patching.sh updater self-OOM check uses name-selector"
 
 # Positive: component remediation loop uses name-selector for container_name, restart_count, term_reason
-component_restart_name_selector=$(grep -c 'containerStatuses\[?(@.name==\\"\$component\\")\].restartCount' "$SRC_FILE" || true)
+component_restart_name_selector=$(grep -c 'containerStatuses\[?(@.name==\\"\$container_name\\")\].restartCount' "$SRC_FILE" || true)
 assert_ge "$component_restart_name_selector" "1" "src/patching.sh component loop reads restartCount via name-selector"
 
-component_term_name_selector=$(grep -c 'containerStatuses\[?(@.name==\\"\$component\\")\].state.terminated.reason' "$SRC_FILE" || true)
+component_term_name_selector=$(grep -c 'containerStatuses\[?(@.name==\\"\$container_name\\")\].state.terminated.reason' "$SRC_FILE" || true)
 assert_ge "$component_term_name_selector" "1" "src/patching.sh component loop reads terminated.reason via name-selector"
 
 # Positive: post-helm agent CronJob health reads terminated.reason/exitCode via AGENT_CONTAINER_NAME

--- a/tests/test-build.sh
+++ b/tests/test-build.sh
@@ -272,7 +272,7 @@ assert_eq "$agent_path_bad_reads" "0" "src/patching.sh agent CPU limit read does
 # _remediate_oomkilled_pod feeds into kubectl set resources — wrong read would
 # cause silent mis-sizing of Prometheus/KSM/OpenCost deployments.
 ###############################################################################
-oom_remediate_name_selector=$(grep -c 'containers\[?(@.name==\\"\$component\\")\].resources.limits.memory' "$SRC_FILE" || true)
+oom_remediate_name_selector=$(grep -c 'containers\[?(@.name==\\"\$container_name\\")\].resources.limits.memory' "$SRC_FILE" || true)
 assert_ge "$oom_remediate_name_selector" "1" "src/patching.sh _remediate_oomkilled_pod reads memory via name-selector"
 
 ###############################################################################


### PR DESCRIPTION
## Summary
- `_detect_pod_failure`: resolve `container_name` by trying short component name, then full deployment name (`onelens-agent-<component>`). Use resolved name for `restartCount` and `terminated.reason` queries instead of raw `$component`.
- `_remediate_oomkilled_pod`: resolve container name (try deployment name, then strip `onelens-agent-` prefix) — the deployment name != container name.
- `_remediate_cpu_starved_pod`: add `-c "$container_name"` to `kubectl set resources`.
- Updated tests to match new variable names in jsonpath selectors.

## Problem
Without proper container name resolution, jsonpath queries like `containers[?(@.name=="prometheus-opencost-exporter")]` return empty when the actual container is named `onelens-agent-prometheus-opencost-exporter`. This causes:
- Missed OOM detection (empty `term_reason`)
- False-positive CPU starvation (empty `oc_cpu` -> `oc_mc=0` -> triggers `< 100` check)
- `kubectl set resources` without `-c` applies to ALL containers including sidecars

## Test plan
- [x] All 848 tests pass
- [ ] Verify on cluster with sidecar-injected pods