### PR TITLE
chore(ci): add Qodo code review caller workflow

### DIFF
--- a/.github/workflows/qodo-review.yml
+++ b/.github/workflows/qodo-review.yml
@@ -1,0 +1,27 @@
+name: Qodo Code Review (Merge Gate)
+on:
+  pull_request:
+    branches: ["main", "master"]
+    types: [opened, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  review:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request_review') ||
+      (github.event_name == 'workflow_dispatch')
+    uses: astuto-ai/.github/.github/workflows/qodo-review.yml@master
+    secrets: inherit


### PR DESCRIPTION
Adds reusable Qodo code review caller workflow. Required for branch protection enforcement.