### PR TITLE
chore(ci): add synchronize trigger to Qodo review

### DIFF
--- a/.github/workflows/qodo-review.yml
+++ b/.github/workflows/qodo-review.yml
@@ -2,7 +2,7 @@ name: Qodo Code Review (Merge Gate)
 on:
   pull_request:
     branches: ["main", "master"]
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
   pull_request_review:
     types: [submitted]
   workflow_dispatch:


### PR DESCRIPTION
Adds 'synchronize' to qodo-review.yml triggers so the check re-runs when commits are pushed after addressing review comments. Currently the check stays Expected forever after the first run.