### PR TITLE
Added rightsizing logic to check periodically even if the pods are he…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -163,8 +163,26 @@ elif [ "$deployment_type" = "cronjob" ]; then
 
     # ─── Routing: healthy vs unhealthy ────────────────────────────────
     if [ -z "$UNHEALTHY_REASONS" ]; then
-        # ALL HEALTHY — decide whether to send heartbeat or exit silently
+        # ALL HEALTHY — check if sizing evaluation is overdue before final verdict
         echo "All healthchecks passed"
+
+        # Check if sizing evaluation is overdue (every 6 hours)
+        _sizing_last_eval=$(kubectl get configmap onelens-agent-sizing-state -n onelens-agent \
+            -o jsonpath='{.data.last_full_evaluation}' 2>/dev/null || true)
+        if [ -n "$_sizing_last_eval" ]; then
+            _sizing_epoch=$(date -u -d "$_sizing_last_eval" +%s 2>/dev/null || \
+                date -u -jf "%Y-%m-%dT%H:%M:%SZ" "$_sizing_last_eval" +%s 2>/dev/null || \
+                echo 0)
+            _sizing_age_secs=$(( $(date -u +%s) - _sizing_epoch ))
+            if [ "$_sizing_age_secs" -ge 21600 ]; then  # 6 hours = 21600 seconds
+                echo "Sizing evaluation overdue (last: $_sizing_last_eval, ${_sizing_age_secs}s ago)"
+                UNHEALTHY_REASONS="Sizing evaluation overdue\n"
+            fi
+        fi
+    fi
+
+    if [ -z "$UNHEALTHY_REASONS" ]; then
+        # TRULY HEALTHY — send heartbeat and manage GPU lifecycle
 
         # PUT heartbeat every run — we're already POSTing every 5 min anyway,
         # so the extra write is negligible. Keeps last_healthy_at fresh for

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -174,7 +174,9 @@ elif [ "$deployment_type" = "cronjob" ]; then
                 date -u -jf "%Y-%m-%dT%H:%M:%SZ" "$_sizing_last_eval" +%s 2>/dev/null || \
                 echo 0)
             _sizing_age_secs=$(( $(date -u +%s) - _sizing_epoch ))
-            if [ "$_sizing_age_secs" -ge 21600 ]; then  # 6 hours = 21600 seconds
+            _SIX_HOURS_IN_SEC=21600
+            _GRACE_PERIOD_IN_SEC=1800  # 30 minutes
+            if [ "$_sizing_age_secs" -ge $((_SIX_HOURS_IN_SEC + _GRACE_PERIOD_IN_SEC)) ]; then
                 echo "Sizing evaluation overdue (last: $_sizing_last_eval, ${_sizing_age_secs}s ago)"
                 UNHEALTHY_REASONS="Sizing evaluation overdue\n"
             fi


### PR DESCRIPTION
### **User description**
…althy


___

### **PR Type**
Enhancement


___

### **Description**
- Adds a periodic resource rightsizing evaluation check.

- Triggers if the last evaluation was over 6 hours ago.

- Marks the agent as unhealthy to initiate the process.

- This ensures rightsizing runs even if pods are healthy.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Initial Health Checks Pass"] --> B{"Sizing Evaluation Overdue?"};
  B -- "Yes (> 6 hours)" --> C["Set UNHEALTHY_REASONS"];
  B -- "No" --> D["Proceed as Healthy (send heartbeat)"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Integrate periodic sizing evaluation into health check logic</code></dd></summary>
<hr>

entrypoint.sh

<ul><li>Checks if the last resource sizing evaluation is older than 6 hours.<br> <li> Retrieves the last evaluation timestamp from the <br><code>onelens-agent-sizing-state</code> ConfigMap.<br> <li> If overdue, sets <code>UNHEALTHY_REASONS</code> to trigger a new sizing process.<br> <li> Ensures periodic rightsizing even when the agent is otherwise healthy.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/369/files#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

