### PR TITLE
Added feature flag to test without any impacts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -167,18 +167,28 @@ elif [ "$deployment_type" = "cronjob" ]; then
         echo "All healthchecks passed"
 
         # Check if sizing evaluation is overdue (every 6 hours)
-        _sizing_last_eval=$(kubectl get configmap onelens-agent-sizing-state -n onelens-agent \
-            -o jsonpath='{.data.last_full_evaluation}' 2>/dev/null || true)
-        if [ -n "$_sizing_last_eval" ]; then
-            _sizing_epoch=$(date -u -d "$_sizing_last_eval" +%s 2>/dev/null || \
-                date -u -jf "%Y-%m-%dT%H:%M:%SZ" "$_sizing_last_eval" +%s 2>/dev/null || \
-                echo 0)
-            _sizing_age_secs=$(( $(date -u +%s) - _sizing_epoch ))
-            _SIX_HOURS_IN_SEC=21600
-            _GRACE_PERIOD_IN_SEC=1800  # 30 minutes
-            if [ "$_sizing_age_secs" -ge $((_SIX_HOURS_IN_SEC + _GRACE_PERIOD_IN_SEC)) ]; then
-                echo "Sizing evaluation overdue (last: $_sizing_last_eval, ${_sizing_age_secs}s ago)"
-                UNHEALTHY_REASONS="Sizing evaluation overdue\n"
+        # Feature-flagged: only runs when ENABLE_PERIODIC_SIZING=true
+        if [ "${ENABLE_PERIODIC_SIZING:-}" = "true" ]; then
+            # Prefer last_sizing_run (written every patching.sh run) so we don't
+            # reset the 72h full-eval cycle. Fall back to last_full_evaluation for
+            # clusters that predate the last_sizing_run field.
+            _sizing_last_run=$(kubectl get configmap onelens-agent-sizing-state -n onelens-agent \
+                -o jsonpath='{.data.last_sizing_run}' 2>/dev/null || true)
+            if [ -z "$_sizing_last_run" ]; then
+                _sizing_last_run=$(kubectl get configmap onelens-agent-sizing-state -n onelens-agent \
+                    -o jsonpath='{.data.last_full_evaluation}' 2>/dev/null || true)
+            fi
+            if [ -n "$_sizing_last_run" ]; then
+                _sizing_epoch=$(date -u -d "$_sizing_last_run" +%s 2>/dev/null || \
+                    date -u -jf "%Y-%m-%dT%H:%M:%SZ" "$_sizing_last_run" +%s 2>/dev/null || \
+                    echo 0)
+                _sizing_age_secs=$(( $(date -u +%s) - _sizing_epoch ))
+                _SIX_HOURS_IN_SEC=21600
+                _GRACE_PERIOD_IN_SEC=1800  # 30 minutes
+                if [ "$_sizing_age_secs" -ge $((_SIX_HOURS_IN_SEC + _GRACE_PERIOD_IN_SEC)) ]; then
+                    echo "Sizing evaluation overdue (last run: $_sizing_last_run, ${_sizing_age_secs}s ago)"
+                    UNHEALTHY_REASONS="Sizing evaluation overdue\n"
+                fi
             fi
         fi
     fi

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -1041,13 +1041,14 @@ if [ -n "$PROM_SVC" ]; then
         echo "Usage-based sizing: no Prometheus data available, keeping tier-based limits"
     fi
 
-    # Always update last_sizing_run regardless of whether Prometheus data was
-    # available. This tells entrypoint.sh that patching.sh ran and evaluated
-    # sizing (even if it had no data to act on), preventing the 6h staleness
-    # check from re-triggering every 5 min.
-    kubectl patch configmap onelens-agent-sizing-state -n onelens-agent \
-        --type merge -p "{\"data\":{\"last_sizing_run\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" 2>/dev/null || true
 fi
+
+# Always update last_sizing_run regardless of whether Prometheus data was
+# available. This tells entrypoint.sh that patching.sh ran and evaluated
+# sizing (even if it had no data to act on), preventing the 6h staleness
+# check from re-triggering every 5 min.
+kubectl patch configmap onelens-agent-sizing-state -n onelens-agent \
+    --type merge -p "{\"data\":{\"last_sizing_run\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" 2>/dev/null || true
 
 # --- GPU monitoring status (Stage 2: Prometheus check) ---
 # Refines GPU_MONITORING_STATUS from Stage 1 by querying for the specific DCGM

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -1040,6 +1040,13 @@ if [ -n "$PROM_SVC" ]; then
     else
         echo "Usage-based sizing: no Prometheus data available, keeping tier-based limits"
     fi
+
+    # Always update last_sizing_run regardless of whether Prometheus data was
+    # available. This tells entrypoint.sh that patching.sh ran and evaluated
+    # sizing (even if it had no data to act on), preventing the 6h staleness
+    # check from re-triggering every 5 min.
+    kubectl patch configmap onelens-agent-sizing-state -n onelens-agent \
+        --type merge -p "{\"data\":{\"last_sizing_run\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" 2>/dev/null || true
 fi
 
 # --- GPU monitoring status (Stage 2: Prometheus check) ---


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improves sizing health check with a new timestamp.

- Prevents false unhealthy alerts for sizing.

- Gates staleness check with a feature flag.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Sizing Script
    A["patching.sh"]
  end
  subgraph Health Check
    C["entrypoint.sh"]
  end
  B["ConfigMap<br/>(last_sizing_run)"]

  A -- "Updates timestamp on every run" --> B
  C -- "Reads timestamp to check for staleness" --> B
  C -- "If stale (>6h)" --> D["Mark Agent as Unhealthy"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Implement feature-flagged sizing staleness check using new timestamp</code></dd></summary>
<hr>

entrypoint.sh

<ul><li>Gates the sizing evaluation overdue check with the <br><code>ENABLE_PERIODIC_SIZING</code> feature flag.<br> <li> Prioritizes reading the new <code>last_sizing_run</code> timestamp to determine if <br>sizing is overdue.<br> <li> Falls back to the <code>last_full_evaluation</code> field for backward <br>compatibility.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/373/files#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2">+22/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>patching.sh</strong><dd><code>Update `last_sizing_run` timestamp on every script execution</code></dd></summary>
<hr>

src/patching.sh

<ul><li>Adds a step to always update the <code>last_sizing_run</code> field in the <br><code>onelens-agent-sizing-state</code> configmap on every execution.<br> <li> This update occurs regardless of whether sizing data was available to <br>act upon.<br> <li> Prevents the health check from incorrectly flagging staleness when the <br>script runs but cannot perform a full evaluation.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/373/files#diff-613ef1c3aac42f47ea79d82c54f83e6564a4db2abf3f3add92d1ee8f80586fbb">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

