### PR TITLE
Made evaluation period configurable

### DIFF
--- a/charts/onelens-agent/charts/onelens-agent-base/values.yaml
+++ b/charts/onelens-agent/charts/onelens-agent-base/values.yaml
@@ -86,6 +86,10 @@ env:
   # Health Checker URLs
   OPENCOST_HEALTH_CHECKER_URL: "http://onelens-agent-prometheus-opencost-exporter:9003/healthz"
   PROMETHEUS_HEALTH_CHECKER_URL: "http://onelens-agent-prometheus-server:80/-/healthy"
+  # Sizing evaluation interval (hours). Controls how often usage-based downsizing
+  # is allowed. Shorter intervals converge faster but need sufficient usage data.
+  # Minimum: 24 (one diurnal cycle). Default: 72.
+  FULL_EVAL_INTERVAL_HOURS: "72"
 secrets:
   # Secrets for onelens-agent
   API_BASE_URL: "https://dev-api.onelens.cloud" # DON'T ADD TRAILING SLASH

--- a/charts/onelens-agent/values.yaml
+++ b/charts/onelens-agent/values.yaml
@@ -82,6 +82,10 @@ onelens-agent:
     # Health Checker URLs
     OPENCOST_HEALTH_CHECKER_URL: "http://onelens-agent-prometheus-opencost-exporter:9003/healthz"
     PROMETHEUS_HEALTH_CHECKER_URL: "http://onelens-agent-prometheus-server:80/-/healthy"
+    # Sizing evaluation interval (hours). Controls how often usage-based downsizing
+    # is allowed. Shorter intervals converge faster but need sufficient usage data.
+    # Minimum: 24 (one diurnal cycle). Default: 72.
+    FULL_EVAL_INTERVAL_HOURS: "72"
   secrets:
     # Secrets for onelens-agent
     API_BASE_URL: "https://dev-api.onelens.cloud" # DON'T ADD TRAILING SLASH

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -476,6 +476,7 @@ if [[ -n "$CURRENT_VALUES" ]] && command -v jq &>/dev/null; then
   PROXY_HTTP=$(_get '.["onelens-agent"].env.HTTP_PROXY')
   PROXY_HTTPS=$(_get '.["onelens-agent"].env.HTTPS_PROXY')
   PROXY_NO=$(_get '.["onelens-agent"].env.NO_PROXY')
+  FULL_EVAL_INTERVAL_HOURS=$(_get '.["onelens-agent"].env.FULL_EVAL_INTERVAL_HOURS')
   # Read user-supplied values WITHOUT -a flag — chart defaults like "false" would
   # be mistaken for customer overrides with -a. Single call for GPU + NC fields.
   _user_vals=$(helm get values onelens-agent -n onelens-agent -o json 2>/dev/null || true)
@@ -570,6 +571,14 @@ else
   SC_EFS_FSID=""
   CUSTOMER_VALUES_FILE=""
   EXISTING_PVC_SIZE=""
+  FULL_EVAL_INTERVAL_HOURS=""
+fi
+
+# Default and validate full eval interval
+FULL_EVAL_INTERVAL_HOURS="${FULL_EVAL_INTERVAL_HOURS:-72}"
+if ! echo "$FULL_EVAL_INTERVAL_HOURS" | grep -qE '^[0-9]+$' || [ "$FULL_EVAL_INTERVAL_HOURS" -lt 24 ]; then
+    echo "WARNING: FULL_EVAL_INTERVAL_HOURS=$FULL_EVAL_INTERVAL_HOURS is invalid (min 24), using default 72"
+    FULL_EVAL_INTERVAL_HOURS=72
 fi
 
 # Validate required identity values
@@ -692,9 +701,10 @@ if [ -n "$PROM_SVC" ]; then
         curl -s -G --max-time 15 "$PROM_QUERY_URL" --data-urlencode "query=$1" 2>/dev/null || true
     }
 
-    # Query 72h max memory and CPU for sizing decisions
-    MEM_72H_RAW=$(_prom_query_raw 'max by (container) (max_over_time(container_memory_working_set_bytes{namespace="onelens-agent",container!="",container!="POD"}[72h]))')
-    CPU_72H_RAW=$(_prom_query_raw 'max by (container) (max_over_time(rate(container_cpu_usage_seconds_total{namespace="onelens-agent",container!="",container!="POD"}[5m])[72h:5m]))')
+    # Query max memory and CPU over the evaluation window for sizing decisions
+    _EVAL_WINDOW="${FULL_EVAL_INTERVAL_HOURS}h"
+    MEM_72H_RAW=$(_prom_query_raw "max by (container) (max_over_time(container_memory_working_set_bytes{namespace=\"onelens-agent\",container!=\"\",container!=\"POD\"}[${_EVAL_WINDOW}]))")
+    CPU_72H_RAW=$(_prom_query_raw "max by (container) (max_over_time(rate(container_cpu_usage_seconds_total{namespace=\"onelens-agent\",container!=\"\",container!=\"POD\"}[5m])[${_EVAL_WINDOW}:5m]))")
 
     # Query current usage for logging (1h window)
     MEM_NOW_RAW=$(_prom_query_raw 'sum by (container) (container_memory_working_set_bytes{namespace="onelens-agent",container!="",container!="POD"})')
@@ -710,7 +720,7 @@ if [ -n "$PROM_SVC" ]; then
 
     # Log current usage (observability)
     if [ -n "$MEM_NOW" ]; then
-        echo "Actual usage (now | max 1h | max 72h):"
+        echo "Actual usage (now | max 1h | max ${FULL_EVAL_INTERVAL_HOURS}h):"
         (
             echo "$MEM_NOW" | while read c v; do echo "mem_now $c $v"; done
             echo "$MEM_1H" | while read c v; do echo "mem_1h $c $v"; done
@@ -787,7 +797,7 @@ if [ -n "$PROM_SVC" ]; then
             --from-literal=kube-state-metrics.last_oom_at="" \
             --from-literal=opencost.last_oom_at="" \
             --from-literal=pushgateway.last_oom_at="" 2>/dev/null || true
-        echo "Created sizing state ConfigMap (first run, downsize deferred 72h)"
+        echo "Created sizing state ConfigMap (first run, downsize deferred ${FULL_EVAL_INTERVAL_HOURS}h)"
         STATE_LAST_FULL_EVAL="$NOW_TS"
         STATE_LAST_OOM_prometheus_server=""
         STATE_LAST_OOM_kube_state_metrics=""
@@ -797,11 +807,11 @@ if [ -n "$PROM_SVC" ]; then
         parse_sizing_state "$CM_JSON"
     fi
 
-    # Determine if 72h full evaluation is due
+    # Determine if full evaluation is due
     FULL_EVAL_DUE=false
-    if is_full_eval_due "$STATE_LAST_FULL_EVAL" 72; then
+    if is_full_eval_due "$STATE_LAST_FULL_EVAL" "$FULL_EVAL_INTERVAL_HOURS"; then
         FULL_EVAL_DUE=true
-        echo "72h full evaluation due (last: $STATE_LAST_FULL_EVAL)"
+        echo "${FULL_EVAL_INTERVAL_HOURS}h full evaluation due (last: $STATE_LAST_FULL_EVAL)"
     fi
 
     # Only proceed with usage-based if we have 72h data
@@ -2530,6 +2540,11 @@ if [ -n "$REGISTRY_URL" ]; then
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.registry=$REGISTRY_URL \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.repository=kube-rbac-proxy \
       --set onelens-agent.env.REGISTRY_URL=$REGISTRY_URL"
+fi
+
+# Sizing interval: preserve customer override across upgrades
+if [ "$FULL_EVAL_INTERVAL_HOURS" != "72" ]; then
+    HELM_CMD="$HELM_CMD --set-string onelens-agent.env.FULL_EVAL_INTERVAL_HOURS=\"$FULL_EVAL_INTERVAL_HOURS\""
 fi
 
 # Proxy: preserve proxy env vars across upgrades

--- a/tests/test-sizing-state.sh
+++ b/tests/test-sizing-state.sh
@@ -63,16 +63,23 @@ assert_exit_code 1 "is_oom_recent: empty timestamp = not recent" is_oom_recent "
 # is_full_eval_due
 ###############################################################################
 
-# 73h ago — should be due
+# 73h ago — should be due (default 72h interval)
 SEVENTY_THREE_H_AGO=$(date -u -v-73H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "73 hours ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
 if [ -n "$SEVENTY_THREE_H_AGO" ]; then
-    assert_exit_code 0 "is_full_eval_due: 73h ago = due" is_full_eval_due "$SEVENTY_THREE_H_AGO" 72
+    assert_exit_code 0 "is_full_eval_due: 73h ago = due (72h interval)" is_full_eval_due "$SEVENTY_THREE_H_AGO" 72
 fi
 
-# 48h ago — not due
+# 48h ago — not due (default 72h interval)
 FORTY_EIGHT_H_AGO=$(date -u -v-48H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "48 hours ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
 if [ -n "$FORTY_EIGHT_H_AGO" ]; then
-    assert_exit_code 1 "is_full_eval_due: 48h ago = not due" is_full_eval_due "$FORTY_EIGHT_H_AGO" 72
+    assert_exit_code 1 "is_full_eval_due: 48h ago = not due (72h interval)" is_full_eval_due "$FORTY_EIGHT_H_AGO" 72
+fi
+
+# 25h ago — should be due with 24h interval
+TWENTY_FIVE_H_AGO=$(date -u -v-25H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "25 hours ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+if [ -n "$TWENTY_FIVE_H_AGO" ]; then
+    assert_exit_code 0 "is_full_eval_due: 25h ago = due (24h interval)" is_full_eval_due "$TWENTY_FIVE_H_AGO" 24
+    assert_exit_code 1 "is_full_eval_due: 25h ago = not due (72h interval)" is_full_eval_due "$TWENTY_FIVE_H_AGO" 72
 fi
 
 # Empty timestamp — NOT due (first run, ConfigMap just created with now)


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Makes sizing evaluation period configurable via `FULL_EVAL_INTERVAL_HOURS`.

- Sets default interval to 72 hours, with a minimum of 24.

- Updates Prometheus queries and sizing logic to use the new interval.

- Adds tests for the configurable interval logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User (values.yaml)"] -- "sets FULL_EVAL_INTERVAL_HOURS" --> B["patching.sh"];
  B -- "Reads & validates interval" --> C["Prometheus Query"];
  B -- "Uses interval" --> D["Sizing Evaluation Logic"];
  C -- "Uses interval in query window" --> E["Resource Usage Data"];
  D -- "Checks if eval is due" --> F["Performs Sizing"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>patching.sh</strong><dd><code>Implement configurable sizing evaluation interval in patching script</code></dd></summary>
<hr>

src/patching.sh

<ul><li>Reads the new <code>FULL_EVAL_INTERVAL_HOURS</code> environment variable from Helm <br>values.<br> <li> Adds validation to ensure the interval is a number and at least 24, <br>defaulting to 72.<br> <li> Replaces hardcoded <code>72h</code> with the configurable interval in Prometheus <br>queries, logic, and log messages.<br> <li> Ensures the custom interval value is preserved during Helm upgrades.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/376/files#diff-613ef1c3aac42f47ea79d82c54f83e6564a4db2abf3f3add92d1ee8f80586fbb">+23/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test-sizing-state.sh</strong><dd><code>Update tests for configurable evaluation interval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test-sizing-state.sh

<ul><li>Adds new test cases for the <code>is_full_eval_due</code> function to verify logic <br>with a custom interval (24h).<br> <li> Updates existing test descriptions to clarify they use the default 72h <br>interval.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/376/files#diff-3bf85fb7e40fef8f049d8509591cec2678d5e7c0e407c43c36e6cecd219cce87">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Expose sizing evaluation interval in base chart values</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/onelens-agent/charts/onelens-agent-base/values.yaml

<ul><li>Adds the <code>FULL_EVAL_INTERVAL_HOURS</code> environment variable under the <code>env</code> <br>section.<br> <li> Sets the default value to "72" and adds comments explaining its <br>purpose and constraints.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/376/files#diff-0e332f11efb2e0430417b5d4abb4e872523620235d9beca38c93f16d72c68d0a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Expose sizing evaluation interval in main chart values</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/onelens-agent/values.yaml

<ul><li>Adds the <code>FULL_EVAL_INTERVAL_HOURS</code> environment variable under <br><code>onelens-agent.env</code>.<br> <li> Sets the default value to "72" and includes comments explaining the <br>new configuration option.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/376/files#diff-e688968305288e338aa873ff711013517be4fa7c1e8c4932a2c0ea98aaf6cfc9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

