### PR TITLE
Fixed code review comments

### DIFF
--- a/src/patching.sh
+++ b/src/patching.sh
@@ -2542,10 +2542,8 @@ if [ -n "$REGISTRY_URL" ]; then
       --set onelens-agent.env.REGISTRY_URL=$REGISTRY_URL"
 fi
 
-# Sizing interval: preserve customer override across upgrades
-if [ "$FULL_EVAL_INTERVAL_HOURS" != "72" ]; then
-    HELM_CMD="$HELM_CMD --set-string onelens-agent.env.FULL_EVAL_INTERVAL_HOURS=\"$FULL_EVAL_INTERVAL_HOURS\""
-fi
+# Sizing interval: always pass to ensure value is correctly applied or reset across upgrades
+HELM_CMD="$HELM_CMD --set-string onelens-agent.env.FULL_EVAL_INTERVAL_HOURS=\"$FULL_EVAL_INTERVAL_HOURS\""
 
 # Proxy: preserve proxy env vars across upgrades
 # Commas in --set values are interpreted as list separators by Helm,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Always pass `FULL_EVAL_INTERVAL_HOURS` to the Helm command.

- This ensures the value is correctly applied or reset during upgrades.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>patching.sh</strong><dd><code>Always pass sizing interval to Helm command during upgrades</code></dd></summary>
<hr>

src/patching.sh

<ul><li>Removed the conditional check that only set <code>FULL_EVAL_INTERVAL_HOURS</code> <br>if it wasn't the default value.<br> <li> The Helm command now unconditionally sets the <br><code>onelens-agent.env.FULL_EVAL_INTERVAL_HOURS</code> variable.<br> <li> This ensures that the sizing interval is correctly applied or reset to <br>its default value during upgrades.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/378/files#diff-613ef1c3aac42f47ea79d82c54f83e6564a4db2abf3f3add92d1ee8f80586fbb">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

