### PR TITLE
Fixed issues in opencost

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -621,6 +621,9 @@ export GKE_DISK_LABELS="${GKE_DISK_LABELS:=}"
 export GKE_ENCRYPTION_ENABLED="${GKE_ENCRYPTION_ENABLED:=false}"
 export GKE_ENCRYPTION_KMS_KEY="${GKE_ENCRYPTION_KMS_KEY:=}"
 
+## GCP API key for OpenCost pricing data (required for GKE clusters)
+export GCP_API_KEY="${GCP_API_KEY:=}"
+
 ## Network cost attribution (opt-in)
 export NETWORK_COSTS_ENABLED="${NETWORK_COSTS_ENABLED:=}"
 
@@ -754,6 +757,24 @@ elif [ "$CLOUD_PROVIDER" = "AZURE" ]; then
     CMD+=" --set onelens-agent.storageClass.azure.skuName=\"$STORAGE_CLASS_SKU\""
 elif [ "$CLOUD_PROVIDER" = "GKE" ]; then
     CMD+=" --set onelens-agent.storageClass.gke.type=\"$STORAGE_CLASS_GKE_TYPE\""
+fi
+
+# GCP API key for OpenCost pricing data (required for GKE)
+if [ "$CLOUD_PROVIDER" = "GKE" ] && [ -n "$GCP_API_KEY" ]; then
+    echo "GCP API key configured for OpenCost pricing data."
+    CMD+=" --set prometheus-opencost-exporter.opencost.exporter.cloudProviderApiKey=\"$GCP_API_KEY\""
+elif [ "$CLOUD_PROVIDER" = "GKE" ] && [ -z "$GCP_API_KEY" ]; then
+    echo "WARNING: GCP_API_KEY is not set. OpenCost will not be able to fetch GCP pricing data."
+    echo "To fix: set GCP_API_KEY env var with a GCP API key that has Cloud Billing API access."
+fi
+
+# GKE: OpenCost needs a writable /var/configs directory to store its GCP pricing config.
+# The container runs as non-root and cannot create /var/configs itself, causing a nil pointer crash.
+if [ "$CLOUD_PROVIDER" = "GKE" ]; then
+    CMD+=" --set prometheus-opencost-exporter.opencost.exporter.extraVolumeMounts[0].name=opencost-config"
+    CMD+=" --set prometheus-opencost-exporter.opencost.exporter.extraVolumeMounts[0].mountPath=/var/configs"
+    CMD+=" --set prometheus-opencost-exporter.extraVolumes[0].name=opencost-config"
+    CMD+=" --set prometheus-opencost-exporter.extraVolumes[0].emptyDir.medium=\"\""
 fi
 
 # Network costs (opt-in)


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes an OpenCost crash on GKE by mounting a writable volume.

- Adds support for `GCP_API_KEY` for OpenCost pricing on GKE.

- Warns users if the `GCP_API_KEY` is not set for GKE clusters.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["install.sh script"] --> B{Is CLOUD_PROVIDER GKE?};
  B -- "Yes" --> C["Add GCP_API_KEY config to Helm command"];
  B -- "Yes" --> D["Add /var/configs volume mount to Helm command"];
  C --> E["Execute Helm install"];
  D --> E;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Add GKE-specific configurations and fixes for OpenCost</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

install.sh

<ul><li>Introduces the <code>GCP_API_KEY</code> environment variable for OpenCost pricing <br>data on GKE.<br> <li> Adds logic to pass the <code>GCP_API_KEY</code> to the Helm chart if provided for a <br>GKE cluster.<br> <li> Mounts an <code>emptyDir</code> volume to <code>/var/configs</code> for the OpenCost container <br>on GKE to prevent a startup crash.<br> <li> Adds a warning message if <code>GCP_API_KEY</code> is not set for a GKE deployment.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/404/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

