### PR TITLE
Fixed updater job issue in gke agent

### DIFF
--- a/src/patching.sh
+++ b/src/patching.sh
@@ -492,6 +492,14 @@ if [[ -n "$CURRENT_VALUES" ]] && command -v jq &>/dev/null; then
   SC_PROVISIONER=$(_get '.["onelens-agent"].storageClass.provisioner')
   SC_EFS_FSID=$(_get '.["onelens-agent"].storageClass.efs.fileSystemId')
 
+  # GKE-specific values (API key, disk type, labels, encryption)
+  GKE_API_KEY=$(_get '.["prometheus-opencost-exporter"].opencost.exporter.cloudProviderApiKey')
+  GKE_DISK_TYPE=$(_get '.["onelens-agent"].storageClass.gke.type')
+  GKE_LABELS_ENABLED=$(_get '.["onelens-agent"].storageClass.gke.labels.enabled')
+  GKE_LABELS_VALUE=$(_get '.["onelens-agent"].storageClass.gke.labels.value')
+  GKE_ENCRYPTION_ENABLED=$(_get '.["onelens-agent"].storageClass.gke.encryption.enabled')
+  GKE_ENCRYPTION_KMS_KEY=$(_get '.["onelens-agent"].storageClass.gke.encryption.kmsKey')
+
   echo "  Cluster: $CLUSTER_NAME | Cloud: $SC_PROVISIONER | PVC: $PVC_ENABLED"
   if [ -n "$REGISTRY_URL" ]; then
       echo "  Air-gapped mode: REGISTRY_URL=$REGISTRY_URL"
@@ -569,6 +577,12 @@ else
   PVC_ENABLED="true"
   SC_PROVISIONER=""
   SC_EFS_FSID=""
+  GKE_API_KEY=""
+  GKE_DISK_TYPE=""
+  GKE_LABELS_ENABLED=""
+  GKE_LABELS_VALUE=""
+  GKE_ENCRYPTION_ENABLED=""
+  GKE_ENCRYPTION_KMS_KEY=""
   CUSTOMER_VALUES_FILE=""
   EXISTING_PVC_SIZE=""
   FULL_EVAL_INTERVAL_HOURS=""
@@ -2486,8 +2500,31 @@ if [ -n "$SC_EFS_FSID" ]; then
     HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.enabled=true"
     HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.provisioner=efs.csi.aws.com"
     HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.efs.fileSystemId=\"$SC_EFS_FSID\""
+elif echo "$SC_PROVISIONER" | grep -q "pd.csi.storage.gke.io"; then
+    HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.enabled=true"
+    HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.provisioner=pd.csi.storage.gke.io"
+    HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.gke.type=\"${GKE_DISK_TYPE:-pd-balanced}\""
+    if [ "$GKE_LABELS_ENABLED" = "true" ] && [ -n "$GKE_LABELS_VALUE" ]; then
+        HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.gke.labels.enabled=true"
+        HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.gke.labels.value=\"$GKE_LABELS_VALUE\""
+    fi
+    if [ "$GKE_ENCRYPTION_ENABLED" = "true" ] && [ -n "$GKE_ENCRYPTION_KMS_KEY" ]; then
+        HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.gke.encryption.enabled=true"
+        HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.gke.encryption.kmsKey=\"$GKE_ENCRYPTION_KMS_KEY\""
+    fi
 else
     HELM_CMD="$HELM_CMD --set onelens-agent.storageClass.enabled=false"
+fi
+
+# GKE: preserve OpenCost API key and writable config volume across upgrades
+if echo "$SC_PROVISIONER" | grep -q "pd.csi.storage.gke.io"; then
+    if [ -n "$GKE_API_KEY" ]; then
+        HELM_CMD="$HELM_CMD --set prometheus-opencost-exporter.opencost.exporter.cloudProviderApiKey=\"$GKE_API_KEY\""
+    fi
+    HELM_CMD="$HELM_CMD --set prometheus-opencost-exporter.opencost.exporter.extraVolumeMounts[0].name=opencost-config"
+    HELM_CMD="$HELM_CMD --set prometheus-opencost-exporter.opencost.exporter.extraVolumeMounts[0].mountPath=/var/configs"
+    HELM_CMD="$HELM_CMD --set prometheus-opencost-exporter.extraVolumes[0].name=opencost-config"
+    HELM_CMD="$HELM_CMD --set prometheus-opencost-exporter.extraVolumes[0].emptyDir.medium=\"\""
 fi
 
 # Retention settings


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Preserves GKE-specific StorageClass settings during updates.

- Retains the OpenCost API key for GKE deployments.

- Mounts a writable config volume for the OpenCost exporter.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["patching.sh execution"] --> B{"GKE Environment?"};
  B -- "Yes" --> C["Read existing GKE config<br/>(StorageClass, API Key)"];
  C --> D["Construct Helm upgrade command"];
  D --> E["Set GKE StorageClass params<br/>(type, labels, encryption)"];
  D --> F["Set OpenCost API Key"];
  D --> G["Mount writable config volume for OpenCost"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>patching.sh</strong><dd><code>Enhance GKE agent update script to preserve configurations</code></dd></summary>
<hr>

src/patching.sh

<ul><li>Extracts GKE-specific settings like StorageClass parameters and the <br>OpenCost API key from the current Helm values.<br> <li> Updates the Helm upgrade command to preserve GKE StorageClass settings <br>(disk type, labels, encryption).<br> <li> Ensures the OpenCost <code>cloudProviderApiKey</code> is retained for GKE <br>deployments across upgrades.<br> <li> Mounts a writable <code>emptyDir</code> volume for the OpenCost exporter to resolve <br>an issue during updates.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/409/files#diff-613ef1c3aac42f47ea79d82c54f83e6564a4db2abf3f3add92d1ee8f80586fbb">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

