### PR TITLE
Corrected the reported EKS cluster version

### DIFF
--- a/scripts/prereq-check/onelens-prereq-check.sh
+++ b/scripts/prereq-check/onelens-prereq-check.sh
@@ -10,6 +10,7 @@
 REQUIRED_URLS=(
     "https://api-in.onelens.cloud"
     "https://astuto-ai.github.io"
+    "https://storage.googleapis.com"
 )
 
 REQUIRED_CONTAINER_REGISTRIES=(
@@ -442,9 +443,10 @@ check_k8s_version() {
     k8s_version=$(
         kubectl version -o json 2>/dev/null | \
             grep -o '"gitVersion": *"v[^"]*"' | \
-            head -1 | \
+            tail -1 | \
             cut -d'"' -f4 | \
-            sed 's/^v//'
+            sed 's/^v//' | \
+            grep -oE '^[0-9]+\.[0-9]+\.[0-9]+'
     )
     
     if [ -z "$k8s_version" ] || [ "$k8s_version" = "null" ]; then


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Correctly detects the Kubernetes server version instead of the client version.

- Improves parsing of the version string to a standard format.

- Adds `storage.googleapis.com` to the list of required URLs.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph K8s Version Check
      A["kubectl version -o json"] --> B{"Get gitVersion"};
      B -- "Previously: head -1 (Client)" --> C["Incorrect Version"];
      B -- "Now: tail -1 (Server)" --> D["Correct Version"];
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>onelens-prereq-check.sh</strong><dd><code>Fix Kubernetes version detection and add required Google Storage URL</code></dd></summary>
<hr>

scripts/prereq-check/onelens-prereq-check.sh

<ul><li>Modifies the <code>check_k8s_version</code> function to use <code>tail -1</code> instead of <code>head </code><br><code>-1</code>, ensuring the script retrieves the server's Kubernetes version, not <br>the client's.<br> <li> Adds a <code>grep</code> command to parse the version string to the <code>X.Y.Z</code> format, <br>making the version check more robust.<br> <li> Adds <code>https://storage.googleapis.com</code> to the <code>REQUIRED_URLS</code> array for the <br>prerequisite check.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/412/files#diff-9f0f0bfaa0c08d77d7ef6809f78cdf38c6263da7e04ff7fc30f34a6955086a83">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

