### PR TITLE
Fixed auto remediation problem

### DIFF
--- a/lib/resource-sizing.sh
+++ b/lib/resource-sizing.sh
@@ -427,19 +427,24 @@ evaluate_container_sizing() {
     # where Prometheus missed the OOM spike (container killed between scrapes)
     # and the termination reason wasn't tagged OOMKilled.
     if [ -n "$mem_now_bytes" ] && [ "$mem_now_bytes" != "0" ]; then
-        local _ual_now_mi _ual_limit_mi
-        # Truncate float to integer to prevent bash arithmetic errors
-        _ual_now_mi=$(( ${mem_now_bytes%.*} / 1048576 ))
+        local _ual_limit_mi
         _ual_limit_mi=$(_memory_to_mi "$current_mem")
-        if [ "$_ual_limit_mi" -gt 0 ] && \
-           [ "$_ual_now_mi" -ge $(( _ual_limit_mi * 90 / 100 )) ] 2>/dev/null; then
-            case "$container" in
-                prom*) new_mem=$(calculate_oom_response_memory "$current_mem" "$mem_cap" 2 1) ;;
-                *)     new_mem=$(calculate_oom_response_memory "$current_mem" "$mem_cap" 3 2) ;;
-            esac
-            echo "MEM=$new_mem"
-            echo "CPU=$new_cpu"
-            return 0
+        # Truncate float to integer (Prometheus can return floats)
+        local _ual_now_int=${mem_now_bytes%.*}
+
+        # Validate numeric before arithmetic
+        if [[ "$_ual_now_int" =~ ^[0-9]+$ && "$_ual_limit_mi" =~ ^[0-9]+$ ]]; then
+            local _ual_now_mi=$(( _ual_now_int / 1048576 ))
+            if [ "$_ual_limit_mi" -gt 0 ] && \
+               [ "$_ual_now_mi" -ge $(( _ual_limit_mi * 90 / 100 )) ]; then
+                case "$container" in
+                    prom*) new_mem=$(calculate_oom_response_memory "$current_mem" "$mem_cap" 2 1) ;;
+                    *)     new_mem=$(calculate_oom_response_memory "$current_mem" "$mem_cap" 3 2) ;;
+                esac
+                echo "MEM=$new_mem"
+                echo "CPU=$new_cpu"
+                return 0
+            fi
         fi
     fi
 

--- a/lib/resource-sizing.sh
+++ b/lib/resource-sizing.sh
@@ -344,13 +344,15 @@ has_sufficient_data() {
 #   "$container" "$current_mem" "$current_cpu" \
 #   "$max_72h_mem_bytes" "$max_72h_cpu_cores" \
 #   "$has_oom_now" "$has_oom_recent" "$is_full_eval" "$is_first_run" \
-#   "$mem_buffer" "$cpu_buffer" "$mem_floor" "$mem_cap" "$cpu_floor" "$cpu_cap"
+#   "$mem_buffer" "$cpu_buffer" "$mem_floor" "$mem_cap" "$cpu_floor" "$cpu_cap" \
+#   "$mem_now_bytes"
 #
 # The master decision function for Prometheus, KSM, OpenCost.
 # Prints two lines: MEM=<value> and CPU=<value>
 # Logic:
 #   - OOM now + not first run: bump memory (2x prom, 1.5x others), capped
 #   - OOM recent (7d hold): HOLD, upsize allowed
+#   - Usage-at-limit: if instantaneous mem usage >= 90% of limit, preemptive bump
 #   - First run: HOLD (no downsize, no OOM reaction)
 #   - Empty Prometheus data: HOLD, upsize allowed
 #   - Full eval (72h): set to usage × buffer (can downsize, with 50% safety guard)
@@ -361,6 +363,7 @@ evaluate_container_sizing() {
     local has_oom_now="$6" has_oom_recent="$7" is_full_eval="$8" is_first_run="$9"
     local mem_buffer="${10}" cpu_buffer="${11}"
     local mem_floor="${12}" mem_cap="${13}" cpu_floor="${14}" cpu_cap="${15}"
+    local mem_now_bytes="${16:-}"
 
     local new_mem="$current_mem"
     local new_cpu="$current_cpu"
@@ -417,6 +420,26 @@ evaluate_container_sizing() {
         echo "MEM=$new_mem"
         echo "CPU=$new_cpu"
         return 0
+    fi
+
+    # Usage-at-limit: if instantaneous memory usage >= 90% of the limit,
+    # the container is about to OOM. Bump preemptively. This catches cases
+    # where Prometheus missed the OOM spike (container killed between scrapes)
+    # and the termination reason wasn't tagged OOMKilled.
+    if [ -n "$mem_now_bytes" ] && [ "$mem_now_bytes" != "0" ]; then
+        local _ual_now_mi _ual_limit_mi
+        _ual_now_mi=$(( mem_now_bytes / 1048576 ))
+        _ual_limit_mi=$(_memory_to_mi "$current_mem")
+        if [ "$_ual_limit_mi" -gt 0 ] && \
+           [ "$_ual_now_mi" -ge $(( _ual_limit_mi * 90 / 100 )) ] 2>/dev/null; then
+            case "$container" in
+                prom*) new_mem=$(calculate_oom_response_memory "$current_mem" "$mem_cap" 2 1) ;;
+                *)     new_mem=$(calculate_oom_response_memory "$current_mem" "$mem_cap" 3 2) ;;
+            esac
+            echo "MEM=$new_mem"
+            echo "CPU=$new_cpu"
+            return 0
+        fi
     fi
 
     # No Prometheus data: HOLD, upsize allowed

--- a/lib/resource-sizing.sh
+++ b/lib/resource-sizing.sh
@@ -428,7 +428,8 @@ evaluate_container_sizing() {
     # and the termination reason wasn't tagged OOMKilled.
     if [ -n "$mem_now_bytes" ] && [ "$mem_now_bytes" != "0" ]; then
         local _ual_now_mi _ual_limit_mi
-        _ual_now_mi=$(( mem_now_bytes / 1048576 ))
+        # Truncate float to integer to prevent bash arithmetic errors
+        _ual_now_mi=$(( ${mem_now_bytes%.*} / 1048576 ))
         _ual_limit_mi=$(_memory_to_mi "$current_mem")
         if [ "$_ual_limit_mi" -gt 0 ] && \
            [ "$_ual_now_mi" -ge $(( _ual_limit_mi * 90 / 100 )) ] 2>/dev/null; then

--- a/lib/resource-sizing.sh
+++ b/lib/resource-sizing.sh
@@ -429,14 +429,16 @@ evaluate_container_sizing() {
     if [ -n "$mem_now_bytes" ] && [ "$mem_now_bytes" != "0" ]; then
         local _ual_limit_mi
         _ual_limit_mi=$(_memory_to_mi "$current_mem")
-        # Truncate float to integer (Prometheus can return floats)
-        local _ual_now_int=${mem_now_bytes%.*}
+        # Safely convert potential float/scientific notation from Prometheus to integer.
+        # printf handles 8.36e+08 correctly; ${%.*} would break on scientific notation.
+        local _ual_now_int
+        _ual_now_int=$(printf "%.0f" "$mem_now_bytes" 2>/dev/null || true)
 
         # Validate numeric before arithmetic
         if [[ "$_ual_now_int" =~ ^[0-9]+$ && "$_ual_limit_mi" =~ ^[0-9]+$ ]]; then
             local _ual_now_mi=$(( _ual_now_int / 1048576 ))
             if [ "$_ual_limit_mi" -gt 0 ] && \
-               [ "$_ual_now_mi" -ge $(( _ual_limit_mi * 90 / 100 )) ]; then
+               [ $(( _ual_now_mi * 100 )) -ge $(( _ual_limit_mi * 90 )) ]; then
                 case "$container" in
                     prom*) new_mem=$(calculate_oom_response_memory "$current_mem" "$mem_cap" 2 1) ;;
                     *)     new_mem=$(calculate_oom_response_memory "$current_mem" "$mem_cap" 3 2) ;;

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -783,14 +783,16 @@ if [ -n "$PROM_SVC" ]; then
         # 2) CrashLoopBackOff — ALWAYS check regardless of OOM_PROM.
         #    Prometheus may report zero OOMs while a pod is crash-looping from
         #    a non-tagged kernel OOM kill (e.g. during WAL replay).
+        #    Require exitCode 137 (SIGKILL) to avoid false positives from
+        #    config errors or other non-OOM crashes.
         _oom_kubectl_crashloop=$(echo "$_pods_json" | jq -r '
             .items[].status.containerStatuses[]? |
-            select(.state.waiting.reason == "CrashLoopBackOff" and .restartCount >= 3) | .name
+            select(.state.waiting.reason == "CrashLoopBackOff" and .restartCount >= 3 and .lastState.terminated.exitCode == 137) | .name
         ' 2>/dev/null || true)
         if [ -n "$_oom_kubectl_crashloop" ]; then
             # Merge with any existing OOM_KUBECTL, dedup
             OOM_KUBECTL=$(printf '%s\n%s' "$OOM_KUBECTL" "$_oom_kubectl_crashloop" | sort -u | sed '/^$/d')
-            echo "OOM detected via kubectl (CrashLoopBackOff + restartCount >= 3):"
+            echo "OOM detected via kubectl (CrashLoopBackOff + restartCount >= 3 + exitCode 137):"
             echo "$_oom_kubectl_crashloop" | while read -r _oname; do echo "  $_oname"; done
         fi
 

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -763,38 +763,46 @@ if [ -n "$PROM_SVC" ]; then
     OOM_PROM_RAW=$(_prom_query_raw 'kube_pod_container_status_last_terminated_reason{namespace="onelens-agent",reason="OOMKilled"}')
     OOM_PROM=$(parse_prom_oom_count "$OOM_PROM_RAW")
 
-    # Kubectl fallback for OOM detection + Pending pod warning
+    # Kubectl-based OOM detection + CrashLoopBackOff detection + Pending pod warning
     OOM_KUBECTL=""
-    if [ -z "$OOM_PROM" ]; then
-        # Fetch pod JSON once for both OOM detection and Pending check
-        _pods_json=$(kubectl get pods -n onelens-agent -o json 2>/dev/null || true)
-
-        # Detect OOM from: (1) lastState.terminated.reason == OOMKilled, or
-        # (2) CrashLoopBackOff with restartCount >= 3 (pod keeps crashing, likely OOM —
-        #     kernel doesn't always label it OOMKilled, e.g. during WAL replay)
-        if [ -n "$_pods_json" ]; then
-            OOM_KUBECTL=$(echo "$_pods_json" | jq -r '
+    _pods_json=$(kubectl get pods -n onelens-agent -o json 2>/dev/null || true)
+    if [ -n "$_pods_json" ]; then
+        # 1) OOMKilled via kubectl — only when Prometheus has no OOM data (fallback)
+        if [ -z "$OOM_PROM" ]; then
+            _oom_kubectl_terminated=$(echo "$_pods_json" | jq -r '
                 .items[].status.containerStatuses[]? |
-                select(
-                    .lastState.terminated.reason == "OOMKilled" or
-                    (.state.waiting.reason == "CrashLoopBackOff" and .restartCount >= 3)
-                ) | .name
+                select(.lastState.terminated.reason == "OOMKilled") | .name
             ' 2>/dev/null || true)
-            if [ -n "$OOM_KUBECTL" ]; then
-                echo "OOM detected via kubectl fallback (Prometheus unavailable for KSM metric):"
-                echo "$OOM_KUBECTL" | while read -r _oname; do echo "  $_oname"; done
+            if [ -n "$_oom_kubectl_terminated" ]; then
+                OOM_KUBECTL="$_oom_kubectl_terminated"
+                echo "OOM detected via kubectl (terminated reason):"
+                echo "$_oom_kubectl_terminated" | while read -r _oname; do echo "  $_oname"; done
             fi
+        fi
 
-            # Warn on pods Pending for >30 minutes (possible node resource exhaustion — don't bump)
-            _pending_warn=$(echo "$_pods_json" | jq -r '
-                .items[] | select(.status.phase == "Pending") |
-                select(now - (.metadata.creationTimestamp | fromdateiso8601) > 1800) |
-                .metadata.name
-            ' 2>/dev/null || true)
-            if [ -n "$_pending_warn" ]; then
-                echo "WARNING: pods Pending for >30 minutes (possible node resource exhaustion):"
-                echo "$_pending_warn" | while read -r _pname; do echo "  $_pname"; done
-            fi
+        # 2) CrashLoopBackOff — ALWAYS check regardless of OOM_PROM.
+        #    Prometheus may report zero OOMs while a pod is crash-looping from
+        #    a non-tagged kernel OOM kill (e.g. during WAL replay).
+        _oom_kubectl_crashloop=$(echo "$_pods_json" | jq -r '
+            .items[].status.containerStatuses[]? |
+            select(.state.waiting.reason == "CrashLoopBackOff" and .restartCount >= 3) | .name
+        ' 2>/dev/null || true)
+        if [ -n "$_oom_kubectl_crashloop" ]; then
+            # Merge with any existing OOM_KUBECTL, dedup
+            OOM_KUBECTL=$(printf '%s\n%s' "$OOM_KUBECTL" "$_oom_kubectl_crashloop" | sort -u | sed '/^$/d')
+            echo "OOM detected via kubectl (CrashLoopBackOff + restartCount >= 3):"
+            echo "$_oom_kubectl_crashloop" | while read -r _oname; do echo "  $_oname"; done
+        fi
+
+        # 3) Pending pod warning — always check
+        _pending_warn=$(echo "$_pods_json" | jq -r '
+            .items[] | select(.status.phase == "Pending") |
+            select(now - (.metadata.creationTimestamp | fromdateiso8601) > 1800) |
+            .metadata.name
+        ' 2>/dev/null || true)
+        if [ -n "$_pending_warn" ]; then
+            echo "WARNING: pods Pending for >30 minutes (possible node resource exhaustion):"
+            echo "$_pending_warn" | while read -r _pname; do echo "  $_pname"; done
         fi
     fi
 
@@ -885,13 +893,14 @@ if [ -n "$PROM_SVC" ]; then
         }
 
         # _evaluate_and_log "$label" "$container_name" "$current_mem" "$current_cpu" \
-        #   "$mem_floor" "$mem_cap" "$oom_state_var"
+        #   "$mem_floor" "$mem_cap" "$oom_state_var" "$cpu_floor" "$mem_now_bytes"
         # Evaluates one component with full diagnostic logging.
         # Sets: _OUT_MEM, _OUT_CPU, increments SIZING_CHANGES if changed.
         _evaluate_and_log() {
             local label="$1" container="$2" cur_mem="$3" cur_cpu="$4"
             local mem_floor="$5" mem_cap="$6" oom_state_var="$7"
             local cpu_floor="${8:-$_USAGE_FLOOR_CPU}"
+            local mem_now_bytes="${9:-}"
 
             local mem_bytes cpu_cores oom_now oom_recent
             mem_bytes=$(_get_container_val "$MEM_72H" "$container")
@@ -918,7 +927,8 @@ if [ -n "$PROM_SVC" ]; then
             result=$(evaluate_container_sizing "$container" \
                 "$cur_mem" "$cur_cpu" "$mem_bytes" "$cpu_cores" \
                 "$oom_now" "$oom_recent" "$FULL_EVAL_DUE" "$IS_FIRST_RUN" \
-                1.35 1.25 "$mem_floor" "$mem_cap" "$cpu_floor" "$_USAGE_CAP_CPU")
+                1.35 1.25 "$mem_floor" "$mem_cap" "$cpu_floor" "$_USAGE_CAP_CPU" \
+                "$mem_now_bytes")
             new_mem=$(echo "$result" | grep '^MEM=' | cut -d= -f2)
             new_cpu=$(echo "$result" | grep '^CPU=' | cut -d= -f2)
 
@@ -990,14 +1000,16 @@ if [ -n "$PROM_SVC" ]; then
         # Evaluate: Prometheus
         _evaluate_and_log "prometheus-server" "prometheus-server" \
             "$PROMETHEUS_MEMORY_LIMIT" "$PROMETHEUS_CPU_LIMIT" \
-            "$_USAGE_FLOOR_PROM_MEM" "$_USAGE_CAP_PROM_MEM" "NEW_PROM_OOM"
+            "$_USAGE_FLOOR_PROM_MEM" "$_USAGE_CAP_PROM_MEM" "NEW_PROM_OOM" \
+            "$_USAGE_FLOOR_CPU" "$(_get_container_val "$MEM_NOW" "prometheus-server")"
         PROMETHEUS_MEMORY_REQUEST="$_OUT_MEM"; PROMETHEUS_MEMORY_LIMIT="$_OUT_MEM"
         PROMETHEUS_CPU_REQUEST="$_OUT_CPU"; PROMETHEUS_CPU_LIMIT="$_OUT_CPU"
 
         # Evaluate: KSM
         _evaluate_and_log "kube-state-metrics" "kube-state-metrics" \
             "$KSM_MEMORY_LIMIT" "$KSM_CPU_LIMIT" \
-            "$_USAGE_FLOOR_KSM_MEM" "$_USAGE_CAP_KSM_MEM" "NEW_KSM_OOM"
+            "$_USAGE_FLOOR_KSM_MEM" "$_USAGE_CAP_KSM_MEM" "NEW_KSM_OOM" \
+            "$_USAGE_FLOOR_CPU" "$(_get_container_val "$MEM_NOW" "kube-state-metrics")"
         KSM_MEMORY_REQUEST="$_OUT_MEM"; KSM_MEMORY_LIMIT="$_OUT_MEM"
         KSM_CPU_REQUEST="$_OUT_CPU"; KSM_CPU_LIMIT="$_OUT_CPU"
 
@@ -1006,7 +1018,8 @@ if [ -n "$PROM_SVC" ]; then
         _evaluate_and_log "opencost" "onelens-agent-prometheus-opencost-exporter" \
             "$OPENCOST_MEMORY_LIMIT" "$OPENCOST_CPU_LIMIT" \
             "$_USAGE_FLOOR_OPENCOST_MEM" "$_USAGE_CAP_OPENCOST_MEM" "NEW_OC_OOM" \
-            "$_USAGE_FLOOR_OPENCOST_CPU"
+            "$_USAGE_FLOOR_OPENCOST_CPU" \
+            "$(_get_container_val "$MEM_NOW" "onelens-agent-prometheus-opencost-exporter")"
         # OpenCost needs ≥100m CPU for startup burst (readiness probe).
         # If pod is Running+NotReady, hold CPU at pre-evaluation value to prevent
         # the vicious cycle where near-zero usage from a starved pod reinforces low CPU.
@@ -1043,7 +1056,8 @@ if [ -n "$PROM_SVC" ]; then
         # (Job-history fallback) that was prone to false-positive bumps.
         _evaluate_and_log "onelens-agent" "onelens-agent" \
             "$ONELENS_MEMORY_LIMIT" "$ONELENS_CPU_LIMIT" \
-            "$_USAGE_FLOOR_AGENT_MEM" "$_USAGE_CAP_AGENT_MEM" "NEW_AGENT_OOM"
+            "$_USAGE_FLOOR_AGENT_MEM" "$_USAGE_CAP_AGENT_MEM" "NEW_AGENT_OOM" \
+            "$_USAGE_FLOOR_CPU" "$(_get_container_val "$MEM_NOW" "onelens-agent")"
         ONELENS_MEMORY_REQUEST="$_OUT_MEM"; ONELENS_MEMORY_LIMIT="$_OUT_MEM"
         ONELENS_CPU_REQUEST="$_OUT_CPU"; ONELENS_CPU_LIMIT="$_OUT_CPU"
 

--- a/tests/test-usage-math.sh
+++ b/tests/test-usage-math.sh
@@ -170,5 +170,50 @@ assert_eq "$(calculate_oom_response_memory "400Mi" 4800)" "800Mi" \
 assert_eq "$_USAGE_CAP_AGENT_MEM" "8192" \
     "_USAGE_CAP_AGENT_MEM raised to 8192 (from 4096) in v2.1.66"
 
+###############################################################################
+# evaluate_container_sizing — usage-at-limit detection (param 16: mem_now_bytes)
+###############################################################################
+
+# Usage at 95% of limit → preemptive 1.5x bump (non-prom container like opencost)
+# 800Mi limit, mem_now = 798Mi (95% = 760Mi threshold), 72h max = 579Mi
+# Should bump: 800Mi * 1.5 = 1200Mi
+_ual_result=$(evaluate_container_sizing "opencost" "800Mi" "100m" \
+    607000000 0.05 false false false false \
+    1.35 1.25 192 4800 50 1200 \
+    836763238)
+_ual_mem=$(echo "$_ual_result" | grep '^MEM=' | cut -d= -f2)
+assert_eq "$_ual_mem" "1200Mi" \
+    "usage-at-limit: 95% of 800Mi limit → 1.5x bump to 1200Mi (non-prom)"
+
+# Usage at 95% of limit → preemptive 2x bump (prometheus container)
+# 800Mi limit, mem_now = 798Mi (95% = 760Mi threshold), 72h max = 579Mi
+# Should bump: 800Mi * 2 = 1600Mi
+_ual_result=$(evaluate_container_sizing "prometheus-server" "800Mi" "100m" \
+    607000000 0.05 false false false false \
+    1.35 1.25 150 8192 50 1200 \
+    836763238)
+_ual_mem=$(echo "$_ual_result" | grep '^MEM=' | cut -d= -f2)
+assert_eq "$_ual_mem" "1600Mi" \
+    "usage-at-limit: 95% of 800Mi limit → 2x bump to 1600Mi (prometheus)"
+
+# Usage at 80% of limit → no bump (below 90% threshold)
+# 800Mi limit, mem_now = 640Mi (80% = below 720Mi threshold), 72h max = 579Mi
+_ual_result=$(evaluate_container_sizing "opencost" "800Mi" "100m" \
+    607000000 0.05 false false false false \
+    1.35 1.25 192 4800 50 1200 \
+    671088640)
+_ual_mem=$(echo "$_ual_result" | grep '^MEM=' | cut -d= -f2)
+assert_eq "$_ual_mem" "800Mi" \
+    "usage-at-limit: 80% of 800Mi limit → no bump (below 90% threshold)"
+
+# Usage at limit with empty mem_now_bytes → no bump (no data)
+_ual_result=$(evaluate_container_sizing "opencost" "800Mi" "100m" \
+    607000000 0.05 false false false false \
+    1.35 1.25 192 4800 50 1200 \
+    "")
+_ual_mem=$(echo "$_ual_result" | grep '^MEM=' | cut -d= -f2)
+assert_eq "$_ual_mem" "800Mi" \
+    "usage-at-limit: empty mem_now_bytes → no bump"
+
 test_summary
 exit $?


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Adds proactive memory increase when usage nears its limit.

- Refines OOM detection using `CrashLoopBackOff` and exit code 137.

- Prevents missed OOM events between Prometheus scrapes.

- Adds unit tests for the new sizing logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Sizing Evaluation
    A["Instantaneous Memory Usage"] --> B{"Usage >= 90% of Limit?"};
    B -- "Yes" --> C["Preemptively Increase Memory"];
    B -- "No" --> D["Continue Normal Sizing Logic"];
  end
  subgraph OOM Detection
    E["kubectl get pods"] --> F{"CrashLoopBackOff + exitCode 137?"};
    F -- "Yes" --> G["Flag as OOM"];
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource-sizing.sh</strong><dd><code>Implement proactive memory increase based on usage-at-limit</code></dd></summary>
<hr>

lib/resource-sizing.sh

<ul><li>Introduces a "usage-at-limit" check in the <code>evaluate_container_sizing</code> <br>function.<br> <li> Preemptively increases memory if instantaneous usage is 90% or more of <br>the current limit.<br> <li> This helps prevent OOMs that occur between Prometheus scrapes and are <br>not reported as <code>OOMKilled</code>.<br> <li> Adds a new <code>mem_now_bytes</code> parameter to support this logic.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/413/files#diff-e25247b3d96817be364dbb3670f40a83875d7d9ec0ac4d0af44d3d2602a342b4">+32/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>patching.sh</strong><dd><code>Refine OOM detection and integrate instantaneous memory data</code></dd></summary>
<hr>

src/patching.sh

<ul><li>Enhances <code>kubectl</code>-based OOM detection to check for <code>CrashLoopBackOff</code> <br>with <code>exitCode 137</code> (SIGKILL).<br> <li> This check now runs regardless of Prometheus data to catch non-tagged <br>kernel OOM kills.<br> <li> Passes instantaneous memory usage data to the <code>_evaluate_and_log</code> <br>function for the new proactive sizing.<br> <li> Refactors OOM detection logic for better clarity and robustness.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/413/files#diff-613ef1c3aac42f47ea79d82c54f83e6564a4db2abf3f3add92d1ee8f80586fbb">+49/-33</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test-usage-math.sh</strong><dd><code>Add unit tests for new proactive memory sizing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test-usage-math.sh

<ul><li>Adds a new test suite for the "usage-at-limit" feature in <br><code>evaluate_container_sizing</code>.<br> <li> Verifies correct memory bumps for both Prometheus and non-Prometheus <br>containers when usage is high.<br> <li> Includes tests for cases where usage is below the threshold or data is <br>unavailable, ensuring no bump occurs.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/413/files#diff-c75d69d55caff95f2ebb9b883119a9e7d6a524886159fd4fb5e3bce9c6653489">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

