### PR TITLE
Fixed test cases

### DIFF
--- a/src/patching.sh
+++ b/src/patching.sh
@@ -477,6 +477,7 @@ if [[ -n "$CURRENT_VALUES" ]] && command -v jq &>/dev/null; then
   PROXY_HTTPS=$(_get '.["onelens-agent"].env.HTTPS_PROXY')
   PROXY_NO=$(_get '.["onelens-agent"].env.NO_PROXY')
   FULL_EVAL_INTERVAL_HOURS=$(_get '.["onelens-agent"].env.FULL_EVAL_INTERVAL_HOURS')
+  METRICS_BACKEND=$(_get '.["onelens-agent"].env.METRICS_BACKEND')
   # Read user-supplied values WITHOUT -a flag — chart defaults like "false" would
   # be mistaken for customer overrides with -a. Single call for GPU + NC fields.
   _user_vals=$(helm get values onelens-agent -n onelens-agent -o json 2>/dev/null || true)
@@ -544,6 +545,10 @@ if [[ -n "$CURRENT_VALUES" ]] && command -v jq &>/dev/null; then
         tolerations: (.["onelens-agent"].cronJob.tolerations // []),
         nodeSelector: (.["onelens-agent"].cronJob.nodeSelector // {}),
         podLabels: (.["onelens-agent"].cronJob.podLabels // {})
+      },
+      victoriaMetrics: {
+        tolerations: (.["onelens-agent"].victoriaMetrics.tolerations // []),
+        nodeSelector: (.["onelens-agent"].victoriaMetrics.nodeSelector // {})
       }
     }
   }' > "$CUSTOMER_VALUES_FILE" 2>/dev/null || true
@@ -586,7 +591,11 @@ else
   CUSTOMER_VALUES_FILE=""
   EXISTING_PVC_SIZE=""
   FULL_EVAL_INTERVAL_HOURS=""
+  METRICS_BACKEND=""
 fi
+
+# Default METRICS_BACKEND to prometheus if not set (fresh installs or pre-VM clusters)
+: "${METRICS_BACKEND:=prometheus}"
 
 # Default and validate full eval interval
 FULL_EVAL_INTERVAL_HOURS="${FULL_EVAL_INTERVAL_HOURS:-72}"
@@ -2576,6 +2585,27 @@ HELM_CMD="$HELM_CMD \
   --set prometheus.configmapReload.prometheus.resources.limits.cpu=\"$PROMETHEUS_CONFIGMAP_RELOAD_CPU_LIMIT\" \
   --set prometheus.configmapReload.prometheus.resources.limits.memory=\"$PROMETHEUS_CONFIGMAP_RELOAD_MEMORY_LIMIT\""
 
+# VictoriaMetrics: when METRICS_BACKEND=victoriametrics, disable Prometheus server
+# but keep KSM and pushgateway (they are subcharts of the prometheus chart).
+if [ "$METRICS_BACKEND" = "victoriametrics" ]; then
+    echo "Metrics backend: VictoriaMetrics (disabling Prometheus server, keeping KSM/pushgateway)"
+    HELM_CMD="$HELM_CMD --set prometheus.server.replicaCount=0"
+    HELM_CMD="$HELM_CMD --set prometheus.server.service.enabled=false"
+    HELM_CMD="$HELM_CMD --set prometheus.server.persistentVolume.enabled=false"
+    HELM_CMD="$HELM_CMD --set prometheus.configmapReload.prometheus.enabled=false"
+    HELM_CMD="$HELM_CMD --set onelens-agent.metricsBackend=victoriametrics"
+    HELM_CMD="$HELM_CMD --set onelens-agent.victoriaMetrics.resources.requests.cpu=\"$PROMETHEUS_CPU_REQUEST\""
+    HELM_CMD="$HELM_CMD --set onelens-agent.victoriaMetrics.resources.requests.memory=\"$PROMETHEUS_MEMORY_REQUEST\""
+    HELM_CMD="$HELM_CMD --set onelens-agent.victoriaMetrics.resources.limits.cpu=\"$PROMETHEUS_CPU_LIMIT\""
+    HELM_CMD="$HELM_CMD --set onelens-agent.victoriaMetrics.resources.limits.memory=\"$PROMETHEUS_MEMORY_LIMIT\""
+    HELM_CMD="$HELM_CMD --set onelens-agent.victoriaMetrics.persistentVolume.enabled=$PVC_ENABLED"
+    HELM_CMD="$HELM_CMD --set-string onelens-agent.victoriaMetrics.persistentVolume.size=\"$PROMETHEUS_VOLUME_SIZE\""
+    HELM_CMD="$HELM_CMD --set-string onelens-agent.victoriaMetrics.retentionPeriod=\"$PROMETHEUS_RETENTION\""
+    HELM_CMD="$HELM_CMD --set onelens-agent.env.PROMETHEUS_HEALTH_CHECKER_URL=\"http://onelens-agent-prometheus-server:80/health\""
+    HELM_CMD="$HELM_CMD --set onelens-agent.env.METRICS_BACKEND=victoriametrics"
+    HELM_CMD="$HELM_CMD --set onelens-agent.env.METRICS_CONTAINER_NAME=victoriametrics"
+fi
+
 # Air-gapped: override all image sources to private registry and persist REGISTRY_URL.
 # Charts that use "{repository}:{tag}" get repository=$REGISTRY_URL/<name>.
 # Charts that use "{registry}/{repository}:{tag}" get registry=$REGISTRY_URL + repository=<name>
@@ -2594,6 +2624,9 @@ if [ -n "$REGISTRY_URL" ]; then
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.registry=$REGISTRY_URL \
       --set prometheus.kube-state-metrics.kubeRBACProxy.image.repository=kube-rbac-proxy \
       --set onelens-agent.env.REGISTRY_URL=$REGISTRY_URL"
+    if [ "$METRICS_BACKEND" = "victoriametrics" ]; then
+        HELM_CMD="$HELM_CMD --set onelens-agent.victoriaMetrics.image.repository=$REGISTRY_URL/victoria-metrics"
+    fi
 fi
 
 # Sizing interval: always pass to ensure value is correctly applied or reset across upgrades

--- a/tests/test-airgapped.sh
+++ b/tests/test-airgapped.sh
@@ -58,8 +58,9 @@ assert_gt "$install_persist" "0" "install.sh persists REGISTRY_URL in helm value
 assert_gt "$patching_persist" "0" "patching.sh re-persists REGISTRY_URL in helm values"
 
 # ---------------------------------------------------------------------------
-# Test 8: Exactly 11 image override flags per script
-# 7 image overrides (some need both registry + repository) + 1 REGISTRY_URL persistence = 11
+# Test 8: Exactly 12 image override flags per script
+# 7 image overrides (some need both registry + repository) + 1 REGISTRY_URL persistence = 11 base
+# + 1 conditional VictoriaMetrics image override = 12 total --set flags.
 # DCGM image is NOT in the helm air-gapped section — it's handled separately via kubectl apply.
 # Components using {registry}/{repository}:{tag} (KSM, OpenCost, kube-rbac-proxy)
 # need both registry and repository overridden to flatten the ECR path.
@@ -67,8 +68,8 @@ assert_gt "$patching_persist" "0" "patching.sh re-persists REGISTRY_URL in helm 
 # ---------------------------------------------------------------------------
 install_override_count=$(sed -n '/Air-gapped: override all image/,/^fi$/p' "$ROOT/install.sh" | grep -c '\-\-set ' || true)
 patching_override_count=$(sed -n '/Air-gapped: override all image/,/^fi$/p' "$ROOT/src/patching.sh" | grep -c '\-\-set ' || true)
-assert_eq "$install_override_count" "11" "install.sh has exactly 11 air-gapped --set flags"
-assert_eq "$patching_override_count" "11" "patching.sh has exactly 11 air-gapped --set flags"
+assert_eq "$install_override_count" "12" "install.sh has exactly 12 air-gapped --set flags"
+assert_eq "$patching_override_count" "12" "patching.sh has exactly 12 air-gapped --set flags"
 
 # ---------------------------------------------------------------------------
 # Test 9: No hardcoded REGISTRY_URL in helm command (parameterized only)


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add support for VictoriaMetrics as a metrics backend.

- Conditionally disable Prometheus if VictoriaMetrics is used.

- Configure VictoriaMetrics resources and persistence via Helm.

- Update air-gapped installation tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Patching Script Execution"] --> B{Check METRICS_BACKEND variable};
  B -- "prometheus (default)" --> C["Configure Helm with Prometheus"];
  B -- "victoriametrics" --> D["Disable Prometheus Server in Helm"];
  D --> E["Configure VictoriaMetrics in Helm"];
  C --> F["Apply Helm Chart"];
  E --> F;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>patching.sh</strong><dd><code>Introduce VictoriaMetrics as an alternative metrics backend</code></dd></summary>
<hr>

src/patching.sh

<ul><li>Adds a <code>METRICS_BACKEND</code> variable to select the metrics backend.<br> <li> Defaults <code>METRICS_BACKEND</code> to <code>prometheus</code> for backward compatibility.<br> <li> Adds a conditional block to disable the Prometheus server and <br>configure VictoriaMetrics when <code>METRICS_BACKEND</code> is <code>victoriametrics</code>.<br> <li> Includes configuration for VictoriaMetrics resources, persistence, and <br>air-gapped image repository.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/417/files#diff-613ef1c3aac42f47ea79d82c54f83e6564a4db2abf3f3add92d1ee8f80586fbb">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test-airgapped.sh</strong><dd><code>Update air-gapped test for VictoriaMetrics image override</code></dd></summary>
<hr>

tests/test-airgapped.sh

<ul><li>Updates comments to reflect the addition of a conditional <br>VictoriaMetrics image override.<br> <li> Increments the expected count of air-gapped <code>--set</code> flags from 11 to 12 <br>to account for the new VictoriaMetrics image.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/417/files#diff-455f399151c2b52c17ed5e8ea41c5fdb24bbf27f3783f1b9c960163405183890">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

