### PR TITLE
Fixed issues

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -337,7 +337,7 @@ DCGM_EOF
                 fi
             else
                 # No GPU nodes — clean up our DCGM if it exists
-                if kubectl get ds nvidia-dcgm-exporter -n onelens-agent -l managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
+                if kubectl get ds -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
                     echo "GPU: cleaning up DCGM exporter (no GPU nodes)"
                     kubectl delete ds nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
                     kubectl delete svc -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens 2>/dev/null || true
@@ -345,7 +345,7 @@ DCGM_EOF
             fi
         else
             # GPU disabled — clean up any previously auto-deployed DCGM (from before this flag existed)
-            if kubectl get ds nvidia-dcgm-exporter -n onelens-agent -l managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
+            if kubectl get ds -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
                 echo "GPU: cleaning up DCGM exporter (gpu.enabled is not true)"
                 kubectl delete ds nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
                 kubectl delete svc -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens 2>/dev/null || true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -339,7 +339,7 @@ DCGM_EOF
                 # No GPU nodes — clean up our DCGM if it exists
                 if kubectl get ds -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
                     echo "GPU: cleaning up DCGM exporter (no GPU nodes)"
-                    kubectl delete ds nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
+                    kubectl delete ds -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens 2>/dev/null || true
                     kubectl delete svc -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens 2>/dev/null || true
                 fi
             fi
@@ -347,7 +347,7 @@ DCGM_EOF
             # GPU disabled — clean up any previously auto-deployed DCGM (from before this flag existed)
             if kubectl get ds -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
                 echo "GPU: cleaning up DCGM exporter (gpu.enabled is not true)"
-                kubectl delete ds nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
+                kubectl delete ds -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens 2>/dev/null || true
                 kubectl delete svc -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens 2>/dev/null || true
             fi
         fi

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -2816,8 +2816,8 @@ elif [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_ENABLED" = "false" ]; then
     # (e.g., customer installed their own DCGM, or GPU nodes were removed)
     if kubectl get ds -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
         echo "Cleaning up OneLens DCGM exporter (no longer needed)"
-        kubectl delete ds nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
-        kubectl delete svc nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
+        kubectl delete ds -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens 2>/dev/null || true
+        kubectl delete svc -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens 2>/dev/null || true
     fi
 fi
 

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -2814,7 +2814,7 @@ DCGM_EOF
 elif [ $UPGRADE_EXIT -eq 0 ] && [ "$GPU_ENABLED" = "false" ]; then
     # Clean up OneLens-managed DCGM if it was previously deployed but is no longer needed
     # (e.g., customer installed their own DCGM, or GPU nodes were removed)
-    if kubectl get ds nvidia-dcgm-exporter -n onelens-agent -l managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
+    if kubectl get ds -n onelens-agent -l app=nvidia-dcgm-exporter,managed-by=onelens --no-headers 2>/dev/null | grep -q .; then
         echo "Cleaning up OneLens DCGM exporter (no longer needed)"
         kubectl delete ds nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true
         kubectl delete svc nvidia-dcgm-exporter -n onelens-agent 2>/dev/null || true


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Refined DCGM exporter cleanup logic in shell scripts.

- Updated `kubectl` commands to use more specific label selectors.

- Improved robustness of finding and deleting DCGM resources.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph DCGM Cleanup Logic
      A["kubectl get/delete ds nvidia-dcgm-exporter"] -- "Less Robust" --> B["Potential Cleanup Failure"];
      C["kubectl get/delete ds -l app=nvidia-dcgm-exporter..."] -- "More Robust" --> D["Reliable Cleanup"];
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Refine DCGM cleanup commands with specific label selectors</code></dd></summary>
<hr>

entrypoint.sh

<ul><li>Updated <code>kubectl get</code> and <code>kubectl delete</code> commands for the DCGM exporter <br>DaemonSet and Service.<br> <li> Replaced selection by resource name with a more specific label <br>selector <code>app=nvidia-dcgm-exporter,managed-by=onelens</code>.<br> <li> This ensures more reliable cleanup of DCGM resources when GPU nodes <br>are not present or GPU monitoring is disabled.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/428/files#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>patching.sh</strong><dd><code>Update DCGM cleanup logic to use label selectors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/patching.sh

<ul><li>Modified <code>kubectl</code> commands for DCGM exporter cleanup during patching.<br> <li> Replaced selection by resource name (<code>nvidia-dcgm-exporter</code>) with a <br>label-based selection (<code>-l </code><br><code>app=nvidia-dcgm-exporter,managed-by=onelens</code>).<br> <li> This change aligns the patching script's cleanup logic with the <br><code>entrypoint.sh</code> script for consistency and robustness.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/428/files#diff-613ef1c3aac42f47ea79d82c54f83e6564a4db2abf3f3add92d1ee8f80586fbb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

