### PR TITLE
Added support for prometheus node exporter pod to scrape node level c…

### DIFF
--- a/charts/onelens-agent/values.yaml
+++ b/charts/onelens-agent/values.yaml
@@ -257,6 +257,21 @@ prometheus:
             - source_labels: [__meta_kubernetes_service_annotation_prometheus_custom_probe]
               action: keep
               regex: pushgateway
+        - job_name: 'node-exporter'
+          scrape_interval: 1m
+          scrape_timeout: 10s
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_node_address_InternalIP]
+              target_label: __address__
+              replacement: $1:9100
+            - source_labels: [__meta_kubernetes_node_name]
+              target_label: node
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: 'node_cpu_seconds_total|node_memory_MemTotal_bytes|node_memory_MemAvailable_bytes|node_memory_MemFree_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes'
+              action: keep
         - job_name: 'kubernetes-services'
           honor_labels: true
           metrics_path: /probe
@@ -371,6 +386,7 @@ prometheus:
       prometheus.custom/probe: pushgateway
   prometheus-node-exporter:
     enabled: false
+    hostPID: false
     nodeSelector:
       kubernetes.io/os: linux
     tolerations:

--- a/charts/onelens-agent/values.yaml
+++ b/charts/onelens-agent/values.yaml
@@ -258,6 +258,7 @@ prometheus:
               action: keep
               regex: pushgateway
         - job_name: 'node-exporter'
+          scheme: http
           scrape_interval: 1m
           scrape_timeout: 10s
           kubernetes_sd_configs:

--- a/globalvalues.yaml
+++ b/globalvalues.yaml
@@ -198,6 +198,21 @@ onelens-agent:
           - source_labels: [__meta_kubernetes_service_annotation_prometheus_custom_probe]
             action: keep
             regex: pushgateway
+      - job_name: 'node-exporter'
+        scrape_interval: 1m
+        scrape_timeout: 10s
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_node_address_InternalIP]
+            target_label: __address__
+            replacement: $1:9100
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: node
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: 'node_cpu_seconds_total|node_memory_MemTotal_bytes|node_memory_MemAvailable_bytes|node_memory_MemFree_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes'
+            action: keep
     extraScrapeConfigs: |
       - job_name: opencost
         honor_labels: true
@@ -582,6 +597,21 @@ prometheus:
             - source_labels: [__meta_kubernetes_service_annotation_prometheus_custom_probe]
               action: keep
               regex: pushgateway
+        - job_name: 'node-exporter'
+          scrape_interval: 1m
+          scrape_timeout: 10s
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_node_address_InternalIP]
+              target_label: __address__
+              replacement: $1:9100
+            - source_labels: [__meta_kubernetes_node_name]
+              target_label: node
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: 'node_cpu_seconds_total|node_memory_MemTotal_bytes|node_memory_MemAvailable_bytes|node_memory_MemFree_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes'
+              action: keep
   alertRelabelConfigs: {}
   networkPolicy:
     enabled: false
@@ -942,6 +972,7 @@ prometheus:
     lifecycle: {}
   prometheus-node-exporter:
     enabled: false
+    hostPID: false
     nodeSelector:
       kubernetes.io/os: linux
     tolerations:

--- a/globalvalues.yaml
+++ b/globalvalues.yaml
@@ -199,6 +199,7 @@ onelens-agent:
             action: keep
             regex: pushgateway
       - job_name: 'node-exporter'
+        scheme: http
         scrape_interval: 1m
         scrape_timeout: 10s
         kubernetes_sd_configs:

--- a/install.sh
+++ b/install.sh
@@ -522,8 +522,9 @@ fi
 # skip deploying ours to avoid port 9100 conflicts. The scrape config
 # targets <node_ip>:9100 regardless — it'll scrape whatever is there.
 NODE_EXPORTER_ENABLED="false"
-_NE_COUNT=$(kubectl get ds --all-namespaces --no-headers 2>/dev/null \
-    | grep -iv "onelens-agent" | awk '$2 ~ /node-exporter/ {print}' | wc -l | tr -d '[:space:]')
+_NE_COUNT=$(kubectl get ds --all-namespaces -o json 2>/dev/null \
+    | jq '[.items[] | select(.metadata.name | test("node-exporter"; "i")) | select(.metadata.namespace | test("onelens-agent"; "i") | not)] | length' 2>/dev/null)
+_NE_COUNT="${_NE_COUNT:-0}"
 if [ "$_NE_COUNT" -gt 0 ]; then
     echo "Node exporter: using existing deployment (detected $_NE_COUNT DaemonSet(s) outside onelens-agent)"
 else

--- a/install.sh
+++ b/install.sh
@@ -523,7 +523,7 @@ fi
 # targets <node_ip>:9100 regardless — it'll scrape whatever is there.
 NODE_EXPORTER_ENABLED="false"
 _NE_COUNT=$(kubectl get ds --all-namespaces --no-headers 2>/dev/null \
-    | grep -iv "onelens-agent" | grep -i "node.exporter" | wc -l | tr -d '[:space:]')
+    | grep -iv "onelens-agent" | grep -i "node-exporter" | wc -l | tr -d '[:space:]')
 if [ "$_NE_COUNT" -gt 0 ]; then
     echo "Node exporter: using existing deployment (detected $_NE_COUNT DaemonSet(s) outside onelens-agent)"
 else

--- a/install.sh
+++ b/install.sh
@@ -523,7 +523,7 @@ fi
 # targets <node_ip>:9100 regardless — it'll scrape whatever is there.
 NODE_EXPORTER_ENABLED="false"
 _NE_COUNT=$(kubectl get ds --all-namespaces --no-headers 2>/dev/null \
-    | grep -iv "onelens-agent" | grep -ic "node.exporter" || echo "0")
+    | grep -iv "onelens-agent" | grep -i "node.exporter" | wc -l | tr -d '[:space:]')
 if [ "$_NE_COUNT" -gt 0 ]; then
     echo "Node exporter: using existing deployment (detected $_NE_COUNT DaemonSet(s) outside onelens-agent)"
 else

--- a/install.sh
+++ b/install.sh
@@ -523,7 +523,7 @@ fi
 # targets <node_ip>:9100 regardless — it'll scrape whatever is there.
 NODE_EXPORTER_ENABLED="false"
 _NE_COUNT=$(kubectl get ds --all-namespaces --no-headers 2>/dev/null \
-    | grep -iv "onelens-agent" | grep -i "node-exporter" | wc -l | tr -d '[:space:]')
+    | grep -iv "onelens-agent" | awk '$2 ~ /node-exporter/ {print}' | wc -l | tr -d '[:space:]')
 if [ "$_NE_COUNT" -gt 0 ]; then
     echo "Node exporter: using existing deployment (detected $_NE_COUNT DaemonSet(s) outside onelens-agent)"
 else

--- a/install.sh
+++ b/install.sh
@@ -517,6 +517,20 @@ if [ "${GPU_MONITORING_ENABLED:-}" = "true" ]; then
     fi
 fi
 
+# --- Node Exporter: detect existing deployment ---
+# If node-exporter already runs in the cluster (customer monitoring stack),
+# skip deploying ours to avoid port 9100 conflicts. The scrape config
+# targets <node_ip>:9100 regardless — it'll scrape whatever is there.
+NODE_EXPORTER_ENABLED="false"
+_NE_COUNT=$(kubectl get ds --all-namespaces --no-headers 2>/dev/null \
+    | grep -iv "onelens-agent" | grep -ic "node.exporter" || echo "0")
+if [ "$_NE_COUNT" -gt 0 ]; then
+    echo "Node exporter: using existing deployment (detected $_NE_COUNT DaemonSet(s) outside onelens-agent)"
+else
+    NODE_EXPORTER_ENABLED="true"
+    echo "Node exporter: deploying (no existing node-exporter detected)"
+fi
+
 # --- Air-gapped self-detection ---
 # If the deployer pod's image is NOT from public.ecr.aws, this is an air-gapped cluster.
 # Extract the private registry URL from the image path for chart pulls and image overrides.
@@ -759,6 +773,10 @@ if [ -n "$REGISTRY_URL" ]; then
     if [ "$METRICS_BACKEND" = "victoriametrics" ]; then
         CMD+=" --set onelens-agent.victoriaMetrics.image.repository=$REGISTRY_URL/victoria-metrics"
     fi
+    if [ "$NODE_EXPORTER_ENABLED" = "true" ]; then
+        CMD+=" --set prometheus.prometheus-node-exporter.image.registry=$REGISTRY_URL"
+        CMD+=" --set prometheus.prometheus-node-exporter.image.repository=node-exporter"
+    fi
 fi
 
 # Proxy: pass effective proxy env vars to onelens-agent sub-chart
@@ -834,6 +852,10 @@ if [ "${NETWORK_COSTS_ENABLED:-}" = "true" ]; then
         CMD+=" --set onelens-agent.networkCosts.image.repository=onelens-network-costs"
     fi
 fi
+
+# Node exporter (auto-detected, skip if customer already has one)
+CMD+=" --set prometheus.prometheus-node-exporter.enabled=$NODE_EXPORTER_ENABLED"
+CMD+=" --set prometheus.prometheus-node-exporter.hostPID=false"
 
 # Multi-AZ storage overrides (EFS for AWS, Azure Files for Azure)
 # These override the default block-storage provisioner with a multi-AZ file-storage provisioner,

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -1189,8 +1189,9 @@ fi
 # skip deploying ours to avoid port 9100 conflicts. The scrape config
 # targets <node_ip>:9100 regardless — it'll scrape whatever is there.
 NODE_EXPORTER_ENABLED="false"
-_NE_COUNT=$(kubectl get ds --all-namespaces --no-headers 2>/dev/null \
-    | grep -iv "onelens-agent" | awk '$2 ~ /node-exporter/ {print}' | wc -l | tr -d '[:space:]')
+_NE_COUNT=$(kubectl get ds --all-namespaces -o json 2>/dev/null \
+    | jq '[.items[] | select(.metadata.name | test("node-exporter"; "i")) | select(.metadata.namespace | test("onelens-agent"; "i") | not)] | length' 2>/dev/null)
+_NE_COUNT="${_NE_COUNT:-0}"
 if [ "$_NE_COUNT" -gt 0 ]; then
     echo "Node exporter: using existing deployment (detected $_NE_COUNT DaemonSet(s) outside onelens-agent)"
 else

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -1190,7 +1190,7 @@ fi
 # targets <node_ip>:9100 regardless — it'll scrape whatever is there.
 NODE_EXPORTER_ENABLED="false"
 _NE_COUNT=$(kubectl get ds --all-namespaces --no-headers 2>/dev/null \
-    | grep -iv "onelens-agent" | grep -i "node.exporter" | wc -l | tr -d '[:space:]')
+    | grep -iv "onelens-agent" | grep -i "node-exporter" | wc -l | tr -d '[:space:]')
 if [ "$_NE_COUNT" -gt 0 ]; then
     echo "Node exporter: using existing deployment (detected $_NE_COUNT DaemonSet(s) outside onelens-agent)"
 else

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -1184,6 +1184,20 @@ if [ "$NC_ENABLED" = "true" ]; then
     fi
 fi
 
+# --- Node Exporter: detect existing deployment ---
+# If node-exporter already runs in the cluster (customer monitoring stack),
+# skip deploying ours to avoid port 9100 conflicts. The scrape config
+# targets <node_ip>:9100 regardless — it'll scrape whatever is there.
+NODE_EXPORTER_ENABLED="false"
+_NE_COUNT=$(kubectl get ds --all-namespaces --no-headers 2>/dev/null \
+    | grep -iv "onelens-agent" | grep -ic "node.exporter" || echo "0")
+if [ "$_NE_COUNT" -gt 0 ]; then
+    echo "Node exporter: using existing deployment (detected $_NE_COUNT DaemonSet(s) outside onelens-agent)"
+else
+    NODE_EXPORTER_ENABLED="true"
+    echo "Node exporter: deploying (no existing node-exporter detected)"
+fi
+
 # --- Agent OOM pre-helm detection ---
 # Agent CronJob OOM must be handled here (before helm upgrade), not in the
 # post-helm Agent CronJob Health section. kubectl patches to CronJobs get
@@ -2628,6 +2642,10 @@ if [ -n "$REGISTRY_URL" ]; then
     if [ "$METRICS_BACKEND" = "victoriametrics" ]; then
         HELM_CMD="$HELM_CMD --set onelens-agent.victoriaMetrics.image.repository=$REGISTRY_URL/victoria-metrics"
     fi
+    if [ "$NODE_EXPORTER_ENABLED" = "true" ]; then
+        HELM_CMD="$HELM_CMD --set prometheus.prometheus-node-exporter.image.registry=$REGISTRY_URL"
+        HELM_CMD="$HELM_CMD --set prometheus.prometheus-node-exporter.image.repository=node-exporter"
+    fi
 fi
 
 # Sizing interval: always pass to ensure value is correctly applied or reset across upgrades
@@ -2662,6 +2680,10 @@ if [ -n "$REGISTRY_URL" ] && [ "$NC_ENABLED" = "true" ]; then
       --set onelens-agent.networkCosts.image.registry=$REGISTRY_URL \
       --set onelens-agent.networkCosts.image.repository=onelens-network-costs"
 fi
+
+# Node exporter (auto-detected, skip if customer already has one)
+HELM_CMD="$HELM_CMD --set prometheus.prometheus-node-exporter.enabled=$NODE_EXPORTER_ENABLED"
+HELM_CMD="$HELM_CMD --set prometheus.prometheus-node-exporter.hostPID=false"
 
 # Force-delete pods stuck in Terminating for >10 min before helm upgrade.
 # Pods on dead/unreachable nodes stay Terminating forever because kubelet can't

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -1190,7 +1190,7 @@ fi
 # targets <node_ip>:9100 regardless — it'll scrape whatever is there.
 NODE_EXPORTER_ENABLED="false"
 _NE_COUNT=$(kubectl get ds --all-namespaces --no-headers 2>/dev/null \
-    | grep -iv "onelens-agent" | grep -ic "node.exporter" || echo "0")
+    | grep -iv "onelens-agent" | grep -i "node.exporter" | wc -l | tr -d '[:space:]')
 if [ "$_NE_COUNT" -gt 0 ]; then
     echo "Node exporter: using existing deployment (detected $_NE_COUNT DaemonSet(s) outside onelens-agent)"
 else

--- a/src/patching.sh
+++ b/src/patching.sh
@@ -1190,7 +1190,7 @@ fi
 # targets <node_ip>:9100 regardless — it'll scrape whatever is there.
 NODE_EXPORTER_ENABLED="false"
 _NE_COUNT=$(kubectl get ds --all-namespaces --no-headers 2>/dev/null \
-    | grep -iv "onelens-agent" | grep -i "node-exporter" | wc -l | tr -d '[:space:]')
+    | grep -iv "onelens-agent" | awk '$2 ~ /node-exporter/ {print}' | wc -l | tr -d '[:space:]')
 if [ "$_NE_COUNT" -gt 0 ]; then
     echo "Node exporter: using existing deployment (detected $_NE_COUNT DaemonSet(s) outside onelens-agent)"
 else


### PR DESCRIPTION
### **User description**
…pu and memory


___

### **PR Type**
Enhancement


___

### **Description**
- Adds support for collecting node-level CPU and memory metrics.

- Auto-detects existing `node-exporter` deployments to avoid conflicts.

- Deploys `prometheus-node-exporter` if no existing one is found.

- Configures Prometheus to scrape and filter essential node metrics.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Installation Script"] --> B{"Existing node-exporter?"};
  B -- "Yes" --> C["Skip deploying OneLens node-exporter"];
  B -- "No" --> D["Deploy OneLens node-exporter"];
  C --> E["Update Prometheus scrape config"];
  D --> E;
  E --> F["Scrape node metrics (CPU/Memory)"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Add auto-detection for existing Node Exporter deployments</code></dd></summary>
<hr>

install.sh

<ul><li>Adds logic to detect if a <code>node-exporter</code> DaemonSet is already running <br>in the cluster.<br> <li> Sets a <code>NODE_EXPORTER_ENABLED</code> variable based on the detection result.<br> <li> Conditionally enables the <code>prometheus-node-exporter</code> Helm chart and sets <br>its image registry for air-gapped environments.<br> <li> Sets <code>prometheus.prometheus-node-exporter.hostPID=false</code> for the <br>deployment.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/431/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>patching.sh</strong><dd><code>Incorporate Node Exporter auto-detection into patching script</code></dd></summary>
<hr>

src/patching.sh

<ul><li>Mirrors the <code>node-exporter</code> auto-detection logic from <code>install.sh</code> for the <br>patching/upgrade process.<br> <li> Avoids deploying a new <code>node-exporter</code> if one already exists to prevent <br>conflicts.<br> <li> Passes Helm values to enable or disable the <code>prometheus-node-exporter</code> <br>chart based on detection.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/431/files#diff-613ef1c3aac42f47ea79d82c54f83e6564a4db2abf3f3add92d1ee8f80586fbb">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Configure Prometheus to scrape and filter Node Exporter metrics</code></dd></summary>
<hr>

charts/onelens-agent/values.yaml

<ul><li>Adds a new Prometheus scrape job configuration for <code>node-exporter</code>.<br> <li> Configures scraping from node internal IPs on port <code>9100</code>.<br> <li> Uses <code>metric_relabel_configs</code> to keep only specific CPU and memory <br>metrics.<br> <li> Adds <code>hostPID: false</code> to the default <code>prometheus-node-exporter</code> values for <br>improved security.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/431/files#diff-e688968305288e338aa873ff711013517be4fa7c1e8c4932a2c0ea98aaf6cfc9">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>globalvalues.yaml</strong><dd><code>Update global values with Node Exporter scrape configuration</code></dd></summary>
<hr>

globalvalues.yaml

<ul><li>Adds the <code>node-exporter</code> scrape configuration to the Prometheus server <br>settings.<br> <li> Filters scraped metrics to retain only essential CPU and memory data.<br> <li> Includes the <code>hostPID: false</code> setting for the <code>prometheus-node-exporter</code> <br>chart.</ul>


</details>


  </td>
  <td><a href="https://github.com/astuto-ai/onelens-installation-scripts/pull/431/files#diff-e6e07798ced097bde5792f0e264048f11d8a7fa8a8d5d5c6199054fe510c9dad">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

